### PR TITLE
NAS-137793 / 26.04 / Fix target attribute removal for mgmt-managed attributes

### DIFF
--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -1265,7 +1265,10 @@ class TestTargetWriter:
 
         # Mock config reader methods
         mock_config_reader._get_current_target_attrs.return_value = {"HeaderDigest": "None", "enabled": "1"}
-        mock_config_reader._get_target_mgmt_info.return_value = {"create_params": {"node_name"}}
+        mock_config_reader._get_target_mgmt_info.return_value = {
+            "create_params": {"node_name"},
+            "target_attributes": {"IncomingUser", "OutgoingUser"}
+        }
 
         # Mock _get_target_create_params to return creation params for new_target only
         def mock_get_create_params(driver, attrs):


### PR DESCRIPTION
Fixes bug where mgmt-managed target attributes (e.g., `IncomingUser`) were not removed when absent from desired configuration. The tool would report "already exists with matching config" even when attributes needed deletion.

Changes:
- Enhanced `attrs_config_differs`() to check for removable mgmt attributes
- Updated `update_target_attributes`() to remove stale mgmt attributes
- Modified `apply_config_assignments`() to read mgmt attributes for comparison
- Added test mock for `target_attributes` in `mgmt_info`