### PR TITLE
NAS-137798 / 26.04 / Fix clear_config to eliminate kernel errors

### DIFF
--- a/scstadmin/admin.py
+++ b/scstadmin/admin.py
@@ -362,7 +362,7 @@ class SCSTAdmin:
                         has_sessions = self.sysfs.valid_path(f"{item_path}/sessions")
 
                         if has_luns or has_ini_groups or has_sessions:
-                            # Remove dynamic target attributes before removing target
+                            # Clear dynamic target attributes before removing target
                             self._clear_target_dynamic_attributes(driver, item)
                             self.target_writer.remove_target(driver, item)
                         else:


### PR DESCRIPTION
Fixes `clear_config` operation which was causing kernel parse errors by attempting to reset global SCST attributes and driver attributes with invalid values (writing '\n' to numeric attributes).

Changes to match original Perl `scstadmin` behavior:
- Remove code that tried to reset global SCST attributes (`setup_id`, `threads`, `trace_level`, etc.) - these caused kernel `kstrtoul`/`kstrtol `parse errors
- Remove code that tried to reset driver attributes to defaults
- Add `_clear_target_dynamic_attributes`() to remove mgmt-managed target attributes (`IncomingUser`, `OutgoingUser`, etc.) before target deletion
- Add `_clear_driver_dynamic_attributes`() to remove mgmt-managed driver attributes after all targets removed

The Perl script only removes configuration objects (devices, targets, groups) and their dynamic mgmt-managed attributes, without resetting static attributes or global settings. Now the Python version does the same.