### PR TITLE
NAS-139563 / 26.0.0-BETA.1 / Fix missing DRIVER_ATTRIBUTES causing virtual target creation failure

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -20,22 +20,22 @@ from .scstadmin import (
     LunConfig,
     InitiatorGroupConfig,
     TargetConfig,
-    DriverConfig
+    DriverConfig,
 )
 
 __all__ = [
-    'SCSTAdmin',
-    'SCSTConfig',
-    'SCSTConfigParser',
-    'SCSTSysfs',
-    'SCSTModuleManager',
-    'SCSTConfigurationReader',
-    'SCSTError',
-    'ConfigAction',
-    'SCSTErrorCode',
-    'SCSTConstants',
-    'LunConfig',
-    'InitiatorGroupConfig',
-    'TargetConfig',
-    'DriverConfig'
+    "SCSTAdmin",
+    "SCSTConfig",
+    "SCSTConfigParser",
+    "SCSTSysfs",
+    "SCSTModuleManager",
+    "SCSTConfigurationReader",
+    "SCSTError",
+    "ConfigAction",
+    "SCSTErrorCode",
+    "SCSTConstants",
+    "LunConfig",
+    "InitiatorGroupConfig",
+    "TargetConfig",
+    "DriverConfig",
 ]

--- a/dev.py
+++ b/dev.py
@@ -90,14 +90,22 @@ def clean_cache(args):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Development helper for SCST Python Configurator")
+    parser = argparse.ArgumentParser(
+        description="Development helper for SCST Python Configurator"
+    )
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
     # Test command
     test_parser = subparsers.add_parser("test", help="Run tests")
-    test_parser.add_argument("--file", help="Run specific test file (e.g., 'admin' for test_admin.py)")
-    test_parser.add_argument("--coverage", action="store_true", help="Run with coverage report")
-    test_parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+    test_parser.add_argument(
+        "--file", help="Run specific test file (e.g., 'admin' for test_admin.py)"
+    )
+    test_parser.add_argument(
+        "--coverage", action="store_true", help="Run with coverage report"
+    )
+    test_parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Verbose output"
+    )
 
     # Lint command
     subparsers.add_parser("lint", help="Run linting")

--- a/scstadmin/__init__.py
+++ b/scstadmin/__init__.py
@@ -21,7 +21,15 @@ Enums:
 
 from .constants import SCSTConstants
 from .exceptions import SCSTError
-from .config import SCSTConfig, ConfigAction, SCSTErrorCode, LunConfig, InitiatorGroupConfig, TargetConfig, DriverConfig
+from .config import (
+    SCSTConfig,
+    ConfigAction,
+    SCSTErrorCode,
+    LunConfig,
+    InitiatorGroupConfig,
+    TargetConfig,
+    DriverConfig,
+)
 from .sysfs import SCSTSysfs
 from .modules import SCSTModuleManager
 from .parser import SCSTConfigParser
@@ -35,18 +43,18 @@ except ImportError:
     pass
 
 __all__ = [
-    'SCSTAdmin',
-    'SCSTConfig',
-    'SCSTConfigParser',
-    'SCSTSysfs',
-    'SCSTModuleManager',
-    'SCSTConfigurationReader',
-    'SCSTError',
-    'ConfigAction',
-    'SCSTErrorCode',
-    'SCSTConstants',
-    'LunConfig',
-    'InitiatorGroupConfig',
-    'TargetConfig',
-    'DriverConfig'
+    "SCSTAdmin",
+    "SCSTConfig",
+    "SCSTConfigParser",
+    "SCSTSysfs",
+    "SCSTModuleManager",
+    "SCSTConfigurationReader",
+    "SCSTError",
+    "ConfigAction",
+    "SCSTErrorCode",
+    "SCSTConstants",
+    "LunConfig",
+    "InitiatorGroupConfig",
+    "TargetConfig",
+    "DriverConfig",
 ]

--- a/scstadmin/admin.py
+++ b/scstadmin/admin.py
@@ -45,13 +45,6 @@ class SCSTAdmin:
 
     VERSION = "SCST Python Configurator v1.0.0"
 
-    # Known driver attributes that should not be treated as targets during cleanup
-    DRIVER_ATTRIBUTES = {
-        'copy_manager': {'dif_capabilities', 'allow_not_connected_copy'},
-        'iscsi': {'link_local', 'isns_entity_name', 'internal_portal', 'trace_level',
-                  'open_state', 'version', 'iSNSServer', 'enabled', 'mgmt'}
-    }
-
     def __init__(self, timeout: int = SCSTConstants.DEFAULT_TIMEOUT, log_level: str = "WARNING"):
         self.sysfs = SCSTSysfs(timeout)
         self.parser = SCSTConfigParser()
@@ -349,7 +342,7 @@ class SCSTAdmin:
                 driver_path = f"{self.sysfs.SCST_TARGETS}/{driver}"
 
                 # Get known driver attributes to skip
-                driver_attrs = self.DRIVER_ATTRIBUTES.get(driver, set())
+                driver_attrs = SCSTConstants.DRIVER_ATTRIBUTES.get(driver, set())
                 driver_attrs.update({self.sysfs.MGMT_INTERFACE, self.sysfs.ENABLED_ATTR})
 
                 for item in self.sysfs.list_directory(driver_path):

--- a/scstadmin/config.py
+++ b/scstadmin/config.py
@@ -13,9 +13,10 @@ from abc import ABC, abstractmethod
 
 class ConfigAction(Enum):
     """Actions that can be taken for existing SCST entities during configuration."""
-    SKIP = "skip"           # Entity already matches configuration
-    UPDATE = "update"       # Only post-creation attributes need updating
-    RECREATE = "recreate"   # Creation attributes differ, entity must be recreated
+
+    SKIP = "skip"  # Entity already matches configuration
+    UPDATE = "update"  # Only post-creation attributes need updating
+    RECREATE = "recreate"  # Creation attributes differ, entity must be recreated
 
 
 class SCSTErrorCode(Enum):
@@ -30,6 +31,7 @@ class SCSTErrorCode(Enum):
         SETATTR_FAIL: Failure to set sysfs attribute values
         FATAL_ERROR: Critical system or configuration errors
     """
+
     BAD_ATTRIBUTES = "SCST_C_BAD_ATTRIBUTES"
     ATTRIBUTE_STATIC = "SCST_C_ATTRIBUTE_STATIC"
     SETATTR_FAIL = "SCST_C_SETATTR_FAIL"
@@ -43,11 +45,12 @@ class DeviceConfig(ABC):
     All SCST devices have a name and belong to a specific handler type.
     Subclasses define the specific attributes required for each handler.
     """
+
     name: str
 
     def __post_init__(self):
         """Initialize attributes dict and validate device configuration."""
-        if not hasattr(self, 'attributes'):
+        if not hasattr(self, "attributes"):
             self.attributes = {}
         if not self.name:
             raise ValueError("Device name cannot be empty")
@@ -79,10 +82,25 @@ class VdiskFileioDeviceConfig(DeviceConfig):
 
     # Creation-time parameters from /sys/kernel/scst_tgt/handlers/vdisk_fileio/mgmt
     _CREATION_PARAMS = {
-        'active', 'async', 'blocksize', 'cluster_mode', 'dif_filename', 'dif_mode',
-        'dif_static_app_tag', 'dif_type', 'filename', 'numa_node_id', 'nv_cache',
-        'o_direct', 'read_only', 'removable', 'rotational', 'thin_provisioned',
-        'tst', 't10_dev_id', 'write_through'
+        "active",
+        "async",
+        "blocksize",
+        "cluster_mode",
+        "dif_filename",
+        "dif_mode",
+        "dif_static_app_tag",
+        "dif_type",
+        "filename",
+        "numa_node_id",
+        "nv_cache",
+        "o_direct",
+        "read_only",
+        "removable",
+        "rotational",
+        "thin_provisioned",
+        "tst",
+        "t10_dev_id",
+        "write_through",
     }
     filename: str
     blocksize: Optional[str] = None
@@ -101,17 +119,17 @@ class VdiskFileioDeviceConfig(DeviceConfig):
         """Return creation-time attributes for vdisk_fileio devices."""
         attrs = {}
         if self.filename:
-            attrs['filename'] = self.filename
+            attrs["filename"] = self.filename
         if self.blocksize:
-            attrs['blocksize'] = self.blocksize
+            attrs["blocksize"] = self.blocksize
         if self.readonly:
-            attrs['read_only'] = self.readonly  # Note: read_only in SCST
+            attrs["read_only"] = self.readonly  # Note: read_only in SCST
         if self.removable:
-            attrs['removable'] = self.removable
+            attrs["removable"] = self.removable
         if self.rotational:
-            attrs['rotational'] = self.rotational
+            attrs["rotational"] = self.rotational
         if self.thin_provisioned:
-            attrs['thin_provisioned'] = self.thin_provisioned
+            attrs["thin_provisioned"] = self.thin_provisioned
         # Additional creation-time parameters from attributes dict
         for param in self._CREATION_PARAMS:
             if param in self.attributes:
@@ -121,10 +139,14 @@ class VdiskFileioDeviceConfig(DeviceConfig):
     @property
     def post_creation_attributes(self) -> Dict[str, str]:
         """Return post-creation attributes (settable after device creation)."""
-        return {k: v for k, v in self.attributes.items() if k not in self._CREATION_PARAMS}
+        return {
+            k: v for k, v in self.attributes.items() if k not in self._CREATION_PARAMS
+        }
 
     @classmethod
-    def from_attributes(cls, name: str, attrs: Dict[str, str]) -> 'VdiskFileioDeviceConfig':
+    def from_attributes(
+        cls, name: str, attrs: Dict[str, str]
+    ) -> "VdiskFileioDeviceConfig":
         """Create VdiskFileioDeviceConfig from flat attributes dict.
 
         Factory method that takes a flat dict of attributes and creates
@@ -139,15 +161,25 @@ class VdiskFileioDeviceConfig(DeviceConfig):
         """
         return cls(
             name=name,
-            filename=attrs.get('filename', ''),
-            blocksize=attrs.get('blocksize'),
-            readonly=attrs.get('readonly'),
-            removable=attrs.get('removable'),
-            rotational=attrs.get('rotational'),
-            thin_provisioned=attrs.get('thin_provisioned'),
-            attributes={k: v for k, v in attrs.items()
-                        if k not in ['filename', 'blocksize', 'readonly', 'removable', 'rotational',
-                                     'thin_provisioned']}
+            filename=attrs.get("filename", ""),
+            blocksize=attrs.get("blocksize"),
+            readonly=attrs.get("readonly"),
+            removable=attrs.get("removable"),
+            rotational=attrs.get("rotational"),
+            thin_provisioned=attrs.get("thin_provisioned"),
+            attributes={
+                k: v
+                for k, v in attrs.items()
+                if k
+                not in [
+                    "filename",
+                    "blocksize",
+                    "readonly",
+                    "removable",
+                    "rotational",
+                    "thin_provisioned",
+                ]
+            },
         )
 
 
@@ -172,9 +204,24 @@ class VdiskBlockioDeviceConfig(DeviceConfig):
 
     # Creation-time parameters from /sys/kernel/scst_tgt/handlers/vdisk_blockio/mgmt
     _CREATION_PARAMS = {
-        'active', 'bind_alua_state', 'blocksize', 'cluster_mode', 'dif_filename', 'dif_mode',
-        'dif_static_app_tag', 'dif_type', 'filename', 'numa_node_id', 'nv_cache',
-        'read_only', 'removable', 'rotational', 'thin_provisioned', 'tst', 't10_dev_id', 'write_through'
+        "active",
+        "bind_alua_state",
+        "blocksize",
+        "cluster_mode",
+        "dif_filename",
+        "dif_mode",
+        "dif_static_app_tag",
+        "dif_type",
+        "filename",
+        "numa_node_id",
+        "nv_cache",
+        "read_only",
+        "removable",
+        "rotational",
+        "thin_provisioned",
+        "tst",
+        "t10_dev_id",
+        "write_through",
     }
     filename: str
     blocksize: Optional[str] = None
@@ -194,19 +241,19 @@ class VdiskBlockioDeviceConfig(DeviceConfig):
         """Return creation-time attributes for vdisk_blockio devices."""
         attrs = {}
         if self.filename:
-            attrs['filename'] = self.filename
+            attrs["filename"] = self.filename
         if self.blocksize:
-            attrs['blocksize'] = self.blocksize
+            attrs["blocksize"] = self.blocksize
         if self.nv_cache:
-            attrs['nv_cache'] = self.nv_cache
+            attrs["nv_cache"] = self.nv_cache
         if self.o_direct:
-            attrs['o_direct'] = self.o_direct
+            attrs["o_direct"] = self.o_direct
         if self.readonly:
-            attrs['read_only'] = self.readonly  # Note: read_only in SCST
+            attrs["read_only"] = self.readonly  # Note: read_only in SCST
         if self.rotational:
-            attrs['rotational'] = self.rotational
+            attrs["rotational"] = self.rotational
         if self.thin_provisioned:
-            attrs['thin_provisioned'] = self.thin_provisioned
+            attrs["thin_provisioned"] = self.thin_provisioned
         # Additional creation-time parameters from attributes dict
         for param in self._CREATION_PARAMS:
             if param in self.attributes:
@@ -216,10 +263,14 @@ class VdiskBlockioDeviceConfig(DeviceConfig):
     @property
     def post_creation_attributes(self) -> Dict[str, str]:
         """Return post-creation attributes (settable after device creation)."""
-        return {k: v for k, v in self.attributes.items() if k not in self._CREATION_PARAMS}
+        return {
+            k: v for k, v in self.attributes.items() if k not in self._CREATION_PARAMS
+        }
 
     @classmethod
-    def from_attributes(cls, name: str, attrs: Dict[str, str]) -> 'VdiskBlockioDeviceConfig':
+    def from_attributes(
+        cls, name: str, attrs: Dict[str, str]
+    ) -> "VdiskBlockioDeviceConfig":
         """Create VdiskBlockioDeviceConfig from flat attributes dict.
 
         Factory method that takes a flat dict of attributes and creates
@@ -234,16 +285,27 @@ class VdiskBlockioDeviceConfig(DeviceConfig):
         """
         return cls(
             name=name,
-            filename=attrs.get('filename', ''),
-            blocksize=attrs.get('blocksize'),
-            nv_cache=attrs.get('nv_cache'),
-            o_direct=attrs.get('o_direct'),
-            readonly=attrs.get('readonly'),
-            rotational=attrs.get('rotational'),
-            thin_provisioned=attrs.get('thin_provisioned'),
-            attributes={k: v for k, v in attrs.items()
-                        if k not in ['filename', 'blocksize', 'nv_cache', 'o_direct', 'readonly',
-                                     'rotational', 'thin_provisioned']}
+            filename=attrs.get("filename", ""),
+            blocksize=attrs.get("blocksize"),
+            nv_cache=attrs.get("nv_cache"),
+            o_direct=attrs.get("o_direct"),
+            readonly=attrs.get("readonly"),
+            rotational=attrs.get("rotational"),
+            thin_provisioned=attrs.get("thin_provisioned"),
+            attributes={
+                k: v
+                for k, v in attrs.items()
+                if k
+                not in [
+                    "filename",
+                    "blocksize",
+                    "nv_cache",
+                    "o_direct",
+                    "readonly",
+                    "rotational",
+                    "thin_provisioned",
+                ]
+            },
         )
 
 
@@ -289,17 +351,17 @@ class DevDiskDeviceConfig(DeviceConfig):
         """Return post-creation attributes (settable after device creation)."""
         attrs = {}
         if self.readonly:
-            attrs['read_only'] = self.readonly  # Note: read_only in SCST
+            attrs["read_only"] = self.readonly  # Note: read_only in SCST
         if self.rotational:
-            attrs['rotational'] = self.rotational
+            attrs["rotational"] = self.rotational
         if self.thin_provisioned:
-            attrs['thin_provisioned'] = self.thin_provisioned
+            attrs["thin_provisioned"] = self.thin_provisioned
         # Add any additional attributes
         attrs.update(self.attributes)
         return attrs
 
     @classmethod
-    def from_attributes(cls, name: str, attrs: Dict[str, str]) -> 'DevDiskDeviceConfig':
+    def from_attributes(cls, name: str, attrs: Dict[str, str]) -> "DevDiskDeviceConfig":
         """Create DevDiskDeviceConfig from flat attributes dict.
 
         Factory method that takes a flat dict of attributes and creates
@@ -314,16 +376,21 @@ class DevDiskDeviceConfig(DeviceConfig):
         """
         return cls(
             name=name,
-            filename=attrs.get('filename', ''),
-            readonly=attrs.get('readonly'),
-            rotational=attrs.get('rotational'),
-            thin_provisioned=attrs.get('thin_provisioned'),
-            attributes={k: v for k, v in attrs.items()
-                        if k not in ['filename', 'readonly', 'rotational', 'thin_provisioned']}
+            filename=attrs.get("filename", ""),
+            readonly=attrs.get("readonly"),
+            rotational=attrs.get("rotational"),
+            thin_provisioned=attrs.get("thin_provisioned"),
+            attributes={
+                k: v
+                for k, v in attrs.items()
+                if k not in ["filename", "readonly", "rotational", "thin_provisioned"]
+            },
         )
 
 
-def create_device_config(name: str, handler_type: str, attrs: Dict[str, str]) -> Optional[DeviceConfig]:
+def create_device_config(
+    name: str, handler_type: str, attrs: Dict[str, str]
+) -> Optional[DeviceConfig]:
     """Factory function to create appropriate DeviceConfig subclass based on handler type.
 
     This function centralizes the logic for creating DeviceConfig objects from flat
@@ -337,11 +404,11 @@ def create_device_config(name: str, handler_type: str, attrs: Dict[str, str]) ->
     Returns:
         Appropriate DeviceConfig subclass instance or None if handler type is unsupported
     """
-    if handler_type == 'vdisk_fileio':
+    if handler_type == "vdisk_fileio":
         return VdiskFileioDeviceConfig.from_attributes(name, attrs)
-    elif handler_type == 'vdisk_blockio':
+    elif handler_type == "vdisk_blockio":
         return VdiskBlockioDeviceConfig.from_attributes(name, attrs)
-    elif handler_type == 'dev_disk':
+    elif handler_type == "dev_disk":
         return DevDiskDeviceConfig.from_attributes(name, attrs)
     else:
         return None
@@ -354,12 +421,15 @@ class LunConfig:
     Represents a LUN assignment within a target, mapping a LUN number
     to a device with optional attributes like read_only access.
     """
+
     lun_number: str  # LUN number (e.g., "0", "1", "255")
-    device: str      # Device name assigned to this LUN
-    attributes: Dict[str, str] = field(default_factory=dict)  # LUN attributes (e.g., read_only)
+    device: str  # Device name assigned to this LUN
+    attributes: Dict[str, str] = field(
+        default_factory=dict
+    )  # LUN attributes (e.g., read_only)
 
     @classmethod
-    def from_config_dict(cls, lun_number: str, lun_data: dict) -> 'LunConfig':
+    def from_config_dict(cls, lun_number: str, lun_data: dict) -> "LunConfig":
         """Create LunConfig from parser dictionary format.
 
         Args:
@@ -371,8 +441,8 @@ class LunConfig:
         """
         return cls(
             lun_number=lun_number,
-            device=lun_data.get('device', ''),
-            attributes=lun_data.get('attributes', {}).copy()
+            device=lun_data.get("device", ""),
+            attributes=lun_data.get("attributes", {}).copy(),
         )
 
 
@@ -383,13 +453,16 @@ class InitiatorGroupConfig:
     Represents an initiator group within a target, containing a list of
     initiators (IQN/portal pairs) and their associated LUN assignments.
     """
+
     name: str  # Group name (e.g., "security_group")
     initiators: List[str] = field(default_factory=list)  # IQN/portal pairs
-    luns: Dict[str, 'LunConfig'] = field(default_factory=dict)  # LUN assignments
+    luns: Dict[str, "LunConfig"] = field(default_factory=dict)  # LUN assignments
     attributes: Dict[str, str] = field(default_factory=dict)  # Group attributes
 
     @classmethod
-    def from_config_dict(cls, group_name: str, group_data: dict) -> 'InitiatorGroupConfig':
+    def from_config_dict(
+        cls, group_name: str, group_data: dict
+    ) -> "InitiatorGroupConfig":
         """Create InitiatorGroupConfig from parser dictionary format.
 
         Args:
@@ -401,9 +474,12 @@ class InitiatorGroupConfig:
         """
         return cls(
             name=group_name,
-            initiators=group_data.get('initiators', []).copy(),
-            luns={lun_id: lun_obj for lun_id, lun_obj in group_data.get('luns', {}).items()},
-            attributes=group_data.get('attributes', {}).copy()
+            initiators=group_data.get("initiators", []).copy(),
+            luns={
+                lun_id: lun_obj
+                for lun_id, lun_obj in group_data.get("luns", {}).items()
+            },
+            attributes=group_data.get("attributes", {}).copy(),
         )
 
 
@@ -428,13 +504,16 @@ class TargetConfig:
             MaxRecvDataSegmentLength 262144
         }
     """
+
     name: str  # Target name/IQN (e.g., "iqn.2024-01.com.example:test")
-    luns: Dict[str, 'LunConfig'] = field(default_factory=dict)  # LUN assignments
-    groups: Dict[str, 'InitiatorGroupConfig'] = field(default_factory=dict)  # Initiator groups
+    luns: Dict[str, "LunConfig"] = field(default_factory=dict)  # LUN assignments
+    groups: Dict[str, "InitiatorGroupConfig"] = field(
+        default_factory=dict
+    )  # Initiator groups
     attributes: Dict[str, str] = field(default_factory=dict)  # Target attributes
 
     @classmethod
-    def from_config_dict(cls, target_name: str, target_data: dict) -> 'TargetConfig':
+    def from_config_dict(cls, target_name: str, target_data: dict) -> "TargetConfig":
         """Create TargetConfig from parser dictionary format.
 
         Args:
@@ -446,9 +525,15 @@ class TargetConfig:
         """
         return cls(
             name=target_name,
-            luns={lun_id: lun_obj for lun_id, lun_obj in target_data.get('luns', {}).items()},
-            groups={group_id: group_obj for group_id, group_obj in target_data.get('groups', {}).items()},
-            attributes=target_data.get('attributes', {}).copy()
+            luns={
+                lun_id: lun_obj
+                for lun_id, lun_obj in target_data.get("luns", {}).items()
+            },
+            groups={
+                group_id: group_obj
+                for group_id, group_obj in target_data.get("groups", {}).items()
+            },
+            attributes=target_data.get("attributes", {}).copy(),
         )
 
 
@@ -470,12 +555,15 @@ class DriverConfig:
             enabled 1
         }
     """
+
     name: str  # Driver name (e.g., "iscsi", "qla2x00t", "copy_manager")
-    targets: Dict[str, 'TargetConfig'] = field(default_factory=dict)  # Target configurations
+    targets: Dict[str, "TargetConfig"] = field(
+        default_factory=dict
+    )  # Target configurations
     attributes: Dict[str, str] = field(default_factory=dict)  # Driver attributes
 
     @classmethod
-    def from_config_dict(cls, driver_name: str, driver_data: dict) -> 'DriverConfig':
+    def from_config_dict(cls, driver_name: str, driver_data: dict) -> "DriverConfig":
         """Create DriverConfig from parser dictionary format.
 
         Args:
@@ -487,8 +575,11 @@ class DriverConfig:
         """
         return cls(
             name=driver_name,
-            targets={target_id: target_obj for target_id, target_obj in driver_data.get('targets', {}).items()},
-            attributes=driver_data.get('attributes', {}).copy()
+            targets={
+                target_id: target_obj
+                for target_id, target_obj in driver_data.get("targets", {}).items()
+            },
+            attributes=driver_data.get("attributes", {}).copy(),
         )
 
 
@@ -505,13 +596,14 @@ class TargetGroupConfig:
         target_attributes: Attributes for individual targets (e.g., rel_tgt_id)
         attributes: Target group attributes (group_id, state, etc.)
     """
+
     name: str
     targets: List[str] = field(default_factory=list)
     target_attributes: Dict[str, Dict[str, str]] = field(default_factory=dict)
     attributes: Dict[str, str] = field(default_factory=dict)
 
     @classmethod
-    def from_config_dict(cls, group_name: str, group_data: dict) -> 'TargetGroupConfig':
+    def from_config_dict(cls, group_name: str, group_data: dict) -> "TargetGroupConfig":
         """Create TargetGroupConfig from dictionary configuration.
 
         Args:
@@ -523,9 +615,9 @@ class TargetGroupConfig:
         """
         return cls(
             name=group_name,
-            targets=group_data.get('targets', []).copy(),
-            target_attributes=group_data.get('target_attributes', {}).copy(),
-            attributes=group_data.get('attributes', {}).copy()
+            targets=group_data.get("targets", []).copy(),
+            target_attributes=group_data.get("target_attributes", {}).copy(),
+            attributes=group_data.get("attributes", {}).copy(),
         )
 
 
@@ -543,13 +635,14 @@ class DeviceGroupConfig:
         target_groups: Target group configurations for ALUA
         attributes: Device group level attributes
     """
+
     name: str
     devices: List[str] = field(default_factory=list)
     target_groups: Dict[str, TargetGroupConfig] = field(default_factory=dict)
     attributes: Dict[str, str] = field(default_factory=dict)
 
     @classmethod
-    def from_config_dict(cls, group_name: str, group_data: dict) -> 'DeviceGroupConfig':
+    def from_config_dict(cls, group_name: str, group_data: dict) -> "DeviceGroupConfig":
         """Create DeviceGroupConfig from dictionary configuration.
 
         Args:
@@ -561,18 +654,20 @@ class DeviceGroupConfig:
         """
         # Handle target groups - convert to TargetGroupConfig objects if needed
         target_groups = {}
-        tg_data = group_data.get('target_groups', {})
+        tg_data = group_data.get("target_groups", {})
         for tg_name, tg_config in tg_data.items():
             if isinstance(tg_config, TargetGroupConfig):
                 target_groups[tg_name] = tg_config
             else:
-                target_groups[tg_name] = TargetGroupConfig.from_config_dict(tg_name, tg_config)
+                target_groups[tg_name] = TargetGroupConfig.from_config_dict(
+                    tg_name, tg_config
+                )
 
         return cls(
             name=group_name,
-            devices=group_data.get('devices', []).copy(),
+            devices=group_data.get("devices", []).copy(),
             target_groups=target_groups,
-            attributes=group_data.get('attributes', {}).copy()
+            attributes=group_data.get("attributes", {}).copy(),
         )
 
 
@@ -595,6 +690,7 @@ class SCSTConfig:
     All attributes are automatically initialized to empty dictionaries
     if not provided during instantiation.
     """
+
     handlers: Optional[Dict[str, Dict]] = None
     devices: Optional[Dict[str, DeviceConfig]] = None
     drivers: Optional[Dict[str, DriverConfig]] = None

--- a/scstadmin/constants.py
+++ b/scstadmin/constants.py
@@ -12,50 +12,63 @@ class SCSTConstants:
     """Constants for SCST configuration and operation."""
 
     # Operation timeouts and intervals
-    DEFAULT_TIMEOUT = 60              # Default timeout for SCST operations (seconds)
-    OPERATION_POLL_INTERVAL = 0.1    # Polling interval for operation completion (seconds)
+    DEFAULT_TIMEOUT = 60  # Default timeout for SCST operations (seconds)
+    OPERATION_POLL_INTERVAL = 0.1  # Polling interval for operation completion (seconds)
 
     # SCST operation results
-    SUCCESS_RESULT = "0"              # SCST success result value
+    SUCCESS_RESULT = "0"  # SCST success result value
 
     # System error codes
-    EAGAIN_ERRNO = errno.EAGAIN       # Resource temporarily unavailable (errno 11)
+    EAGAIN_ERRNO = errno.EAGAIN  # Resource temporarily unavailable (errno 11)
 
     # Kernel module mappings (based on SCST init script)
     HANDLER_MODULE_MAP = {
-        'dev_cdrom': 'scst_cdrom',
-        'dev_changer': 'scst_changer',
-        'dev_disk': 'scst_disk',
-        'dev_disk_perf': 'scst_disk',
-        'dev_modisk': 'scst_modisk',
-        'dev_modisk_perf': 'scst_modisk',
-        'dev_processor': 'scst_processor',
-        'dev_raid': 'scst_raid',
-        'dev_tape': 'scst_tape',
-        'dev_tape_perf': 'scst_tape',
-        'dev_user': 'scst_user',
-        'vdisk_blockio': 'scst_vdisk',
-        'vdisk_fileio': 'scst_vdisk',
-        'vdisk_nullio': 'scst_vdisk',
-        'vcdrom': 'scst_vdisk',
+        "dev_cdrom": "scst_cdrom",
+        "dev_changer": "scst_changer",
+        "dev_disk": "scst_disk",
+        "dev_disk_perf": "scst_disk",
+        "dev_modisk": "scst_modisk",
+        "dev_modisk_perf": "scst_modisk",
+        "dev_processor": "scst_processor",
+        "dev_raid": "scst_raid",
+        "dev_tape": "scst_tape",
+        "dev_tape_perf": "scst_tape",
+        "dev_user": "scst_user",
+        "vdisk_blockio": "scst_vdisk",
+        "vdisk_fileio": "scst_vdisk",
+        "vdisk_nullio": "scst_vdisk",
+        "vcdrom": "scst_vdisk",
     }
 
     DRIVER_MODULE_MAP = {
-        'iscsi': 'iscsi_scst',
-        'qla2x00t': 'qla2x00tgt',
-        'copy_manager': None,  # Built into scst core
+        "iscsi": "iscsi_scst",
+        "qla2x00t": "qla2x00tgt",
+        "copy_manager": None,  # Built into scst core
     }
 
     # Driver attributes that should be filtered when scanning for targets
     # These are driver-level configuration files/directories, not actual targets
     DRIVER_ATTRIBUTES = {
-        'copy_manager': {'copy_manager_tgt', 'dif_capabilities', 'allow_not_connected_copy'},
-        'iscsi': {'link_local', 'isns_entity_name', 'internal_portal', 'trace_level',
-                  'open_state', 'version', 'iSNSServer', 'enabled', 'mgmt'},
-        'qla2x00t': {'trace_level', 'version', 'mgmt'}
+        "copy_manager": {
+            "copy_manager_tgt",
+            "dif_capabilities",
+            "allow_not_connected_copy",
+        },
+        "iscsi": {
+            "link_local",
+            "isns_entity_name",
+            "internal_portal",
+            "trace_level",
+            "open_state",
+            "version",
+            "iSNSServer",
+            "enabled",
+            "mgmt",
+        },
+        "qla2x00t": {"trace_level", "version", "mgmt"},
     }
 
     # Optional modules for specific architectures/drivers
     # Handle isert_scst elsewhere
-    ISCSI_OPT_MODULES = ['crc32c']
-    ISCSI_X86_MODULES = ['crc32c-intel']
+    ISCSI_OPT_MODULES = ["crc32c"]
+    ISCSI_X86_MODULES = ["crc32c-intel"]

--- a/scstadmin/constants.py
+++ b/scstadmin/constants.py
@@ -46,6 +46,15 @@ class SCSTConstants:
         'copy_manager': None,  # Built into scst core
     }
 
+    # Driver attributes that should be filtered when scanning for targets
+    # These are driver-level configuration files/directories, not actual targets
+    DRIVER_ATTRIBUTES = {
+        'copy_manager': {'copy_manager_tgt', 'dif_capabilities', 'allow_not_connected_copy'},
+        'iscsi': {'link_local', 'isns_entity_name', 'internal_portal', 'trace_level',
+                  'open_state', 'version', 'iSNSServer', 'enabled', 'mgmt'},
+        'qla2x00t': {'trace_level', 'version', 'mgmt'}
+    }
+
     # Optional modules for specific architectures/drivers
     # Handle isert_scst elsewhere
     ISCSI_OPT_MODULES = ['crc32c']

--- a/scstadmin/exceptions.py
+++ b/scstadmin/exceptions.py
@@ -18,4 +18,5 @@ class SCSTError(Exception):
     All SCST Python configurator operations should catch and handle SCSTError
     rather than generic exceptions for proper error handling.
     """
+
     pass

--- a/scstadmin/readers/__init__.py
+++ b/scstadmin/readers/__init__.py
@@ -14,8 +14,8 @@ from .group_reader import DeviceGroupReader
 from .config_reader import SCSTConfigurationReader
 
 __all__ = [
-    'DeviceReader',
-    'TargetReader',
-    'DeviceGroupReader',
-    'SCSTConfigurationReader'
+    "DeviceReader",
+    "TargetReader",
+    "DeviceGroupReader",
+    "SCSTConfigurationReader",
 ]

--- a/scstadmin/readers/config_reader.py
+++ b/scstadmin/readers/config_reader.py
@@ -94,7 +94,7 @@ class SCSTConfigurationReader:
             raw_stripped = raw_value.strip()
 
             # Check if it has the [key] suffix indicating non-default value
-            if raw_stripped.endswith('[key]'):
+            if raw_stripped.endswith("[key]"):
                 # Strip off the [key] suffix to get clean value
                 clean_value = raw_stripped[:-5].strip()
                 return clean_value
@@ -109,21 +109,31 @@ class SCSTConfigurationReader:
         return self.sysfs.valid_path(self.sysfs.SCST_ROOT)
 
     # Delegate methods to specialized readers for backward compatibility
-    def _get_current_device_attrs(self, handler: str, device_name: str,
-                                  filter_attrs: Optional[Set[str]] = None) -> Dict[str, str]:
+    def _get_current_device_attrs(
+        self, handler: str, device_name: str, filter_attrs: Optional[Set[str]] = None
+    ) -> Dict[str, str]:
         """Delegate to DeviceReader for backward compatibility"""
-        return self.device_reader._get_current_device_attrs(handler, device_name, filter_attrs)
+        return self.device_reader._get_current_device_attrs(
+            handler, device_name, filter_attrs
+        )
 
-    def _get_current_target_attrs(self, driver: str, target_name: str,
-                                  filter_attrs: Optional[Set[str]] = None) -> Dict[str, str]:
+    def _get_current_target_attrs(
+        self, driver: str, target_name: str, filter_attrs: Optional[Set[str]] = None
+    ) -> Dict[str, str]:
         """Delegate to TargetReader for backward compatibility"""
-        return self.target_reader._get_current_target_attrs(driver, target_name, filter_attrs)
+        return self.target_reader._get_current_target_attrs(
+            driver, target_name, filter_attrs
+        )
 
-    def _get_target_create_params(self, driver_name: str, target_attrs: Dict[str, str]) -> Dict[str, str]:
+    def _get_target_create_params(
+        self, driver_name: str, target_attrs: Dict[str, str]
+    ) -> Dict[str, str]:
         """Delegate to TargetReader for backward compatibility"""
         return self.target_reader._get_target_create_params(driver_name, target_attrs)
 
-    def _get_lun_create_params(self, driver: str, target: str, lun_attrs: Dict[str, str]) -> Dict[str, str]:
+    def _get_lun_create_params(
+        self, driver: str, target: str, lun_attrs: Dict[str, str]
+    ) -> Dict[str, str]:
         """Delegate to TargetReader for backward compatibility"""
         return self.target_reader._get_lun_create_params(driver, target, lun_attrs)
 
@@ -131,11 +141,17 @@ class SCSTConfigurationReader:
         """Delegate to TargetReader for backward compatibility"""
         return self.target_reader._get_current_lun_device(driver, target, lun_number)
 
-    def _get_current_group_lun_device(self, driver: str, target: str, group_name: str, lun_number: str) -> str:
+    def _get_current_group_lun_device(
+        self, driver: str, target: str, group_name: str, lun_number: str
+    ) -> str:
         """Delegate to TargetReader for backward compatibility"""
-        return self.target_reader._get_current_group_lun_device(driver, target, group_name, lun_number)
+        return self.target_reader._get_current_group_lun_device(
+            driver, target, group_name, lun_number
+        )
 
-    def _get_driver_attribute_default(self, driver_name: str, attr_name: str) -> Optional[str]:
+    def _get_driver_attribute_default(
+        self, driver_name: str, attr_name: str
+    ) -> Optional[str]:
         """Delegate to TargetReader for backward compatibility"""
         return self.target_reader._get_driver_attribute_default(driver_name, attr_name)
 

--- a/scstadmin/readers/device_reader.py
+++ b/scstadmin/readers/device_reader.py
@@ -43,10 +43,14 @@ class DeviceReader:
                 handler_type = os.path.basename(target)
                 return handler_type
         except (OSError, IOError) as e:
-            self.logger.warning("Failed to read handler type for device '%s': %s", device_name, e)
+            self.logger.warning(
+                "Failed to read handler type for device '%s': %s", device_name, e
+            )
         return None
 
-    def _create_minimal_device_config(self, device_name: str, handler_type: str) -> Optional['DeviceConfig']:
+    def _create_minimal_device_config(
+        self, device_name: str, handler_type: str
+    ) -> Optional["DeviceConfig"]:
         """Create a minimal DeviceConfig object for cleanup operations.
 
         Args:
@@ -58,13 +62,24 @@ class DeviceReader:
         """
         try:
             # Create minimal device config with empty filename for cleanup operations
-            minimal_attrs = {'filename': ''}  # Required field for all device types
-            device_config = create_device_config(device_name, handler_type, minimal_attrs)
+            minimal_attrs = {"filename": ""}  # Required field for all device types
+            device_config = create_device_config(
+                device_name, handler_type, minimal_attrs
+            )
             if device_config is None:
-                self.logger.error("Unknown handler type '%s' for device '%s', skipping", handler_type, device_name)
+                self.logger.error(
+                    "Unknown handler type '%s' for device '%s', skipping",
+                    handler_type,
+                    device_name,
+                )
             return device_config
         except (ValueError, TypeError) as e:
-            self.logger.error("Failed to create DeviceConfig for '%s' (handler: %s): %s", device_name, handler_type, e)
+            self.logger.error(
+                "Failed to create DeviceConfig for '%s' (handler: %s): %s",
+                device_name,
+                handler_type,
+                e,
+            )
             return None
 
     def _safe_read_attribute(self, attr_path: str) -> Optional[str]:
@@ -76,8 +91,9 @@ class DeviceReader:
             pass
         return None
 
-    def _get_current_device_attrs(self, handler: str, device_name: str,
-                                  filter_attrs: Optional[Set[str]] = None) -> Dict[str, str]:
+    def _get_current_device_attrs(
+        self, handler: str, device_name: str, filter_attrs: Optional[Set[str]] = None
+    ) -> Dict[str, str]:
         """Read current device attributes from SCST sysfs interface.
 
         This method reads the live attribute values for an existing SCST device
@@ -112,7 +128,7 @@ class DeviceReader:
             # If filter is provided, only read those specific attributes
             if filter_attrs:
                 for attr in filter_attrs:
-                    if attr == 'handler':  # Skip handler attribute
+                    if attr == "handler":  # Skip handler attribute
                         continue
                     attr_path = os.path.join(device_path, attr)
                     value = self._safe_read_attribute(attr_path)
@@ -122,7 +138,7 @@ class DeviceReader:
                 # Read all attribute files in the device directory (fallback)
                 for item in os.listdir(device_path):
                     item_path = os.path.join(device_path, item)
-                    if not item.startswith('.'):
+                    if not item.startswith("."):
                         value = self._safe_read_attribute(item_path)
                         if value is not None:
                             attrs[item] = value
@@ -176,7 +192,9 @@ class DeviceReader:
 
         for device in self.sysfs.list_directory(devices_path):
             if handler_type := self._get_device_handler_type(device):
-                if device_config := self._create_minimal_device_config(device, handler_type):
+                if device_config := self._create_minimal_device_config(
+                    device, handler_type
+                ):
                     devices[device] = device_config
 
         return devices

--- a/scstadmin/readers/group_reader.py
+++ b/scstadmin/readers/group_reader.py
@@ -22,7 +22,7 @@ class DeviceGroupReader:
     """
 
     # Constants needed for reading configuration
-    MGMT_INTERFACE = 'mgmt'
+    MGMT_INTERFACE = "mgmt"
 
     def __init__(self, sysfs: SCSTSysfs):
         self.sysfs = sysfs
@@ -41,11 +41,7 @@ class DeviceGroupReader:
 
         for group_name in self.sysfs.list_directory(self.sysfs.SCST_DEV_GROUPS):
             if group_name != self.MGMT_INTERFACE:
-                group_config = {
-                    'devices': [],
-                    'target_groups': {},
-                    'attributes': {}
-                }
+                group_config = {"devices": [], "target_groups": {}, "attributes": {}}
 
                 group_path = f"{self.sysfs.SCST_DEV_GROUPS}/{group_name}"
 
@@ -54,7 +50,7 @@ class DeviceGroupReader:
                 if self.sysfs.valid_path(devices_path):
                     for device in self.sysfs.list_directory(devices_path):
                         if device != self.MGMT_INTERFACE:
-                            group_config['devices'].append(device)
+                            group_config["devices"].append(device)
 
                 # Read target groups in group
                 target_groups_path = f"{group_path}/target_groups"
@@ -62,9 +58,9 @@ class DeviceGroupReader:
                     for tgroup_name in self.sysfs.list_directory(target_groups_path):
                         if tgroup_name != self.MGMT_INTERFACE:
                             tgroup_config = {
-                                'targets': [],
-                                'target_attributes': {},
-                                'attributes': {}
+                                "targets": [],
+                                "target_attributes": {},
+                                "attributes": {},
                             }
 
                             tgroup_path = f"{target_groups_path}/{tgroup_name}"
@@ -73,7 +69,7 @@ class DeviceGroupReader:
                             for target in self.sysfs.list_directory(tgroup_path):
                                 if target != self.MGMT_INTERFACE:
                                     # Add target name to targets list
-                                    tgroup_config['targets'].append(target)
+                                    tgroup_config["targets"].append(target)
 
                                     target_path = f"{tgroup_path}/{target}"
                                     target_attributes = {}
@@ -83,10 +79,17 @@ class DeviceGroupReader:
                                         try:
                                             for attr_file in os.listdir(target_path):
                                                 attr_path = f"{target_path}/{attr_file}"
-                                                if os.path.isfile(attr_path) and attr_file != self.MGMT_INTERFACE:
+                                                if (
+                                                    os.path.isfile(attr_path)
+                                                    and attr_file != self.MGMT_INTERFACE
+                                                ):
                                                     try:
-                                                        attr_value = self.sysfs.read_sysfs_attribute(attr_path)
-                                                        target_attributes[attr_file] = attr_value
+                                                        attr_value = self.sysfs.read_sysfs_attribute(
+                                                            attr_path
+                                                        )
+                                                        target_attributes[attr_file] = (
+                                                            attr_value
+                                                        )
                                                     except SCSTError:
                                                         pass  # Skip unreadable attributes
                                         except (OSError, IOError):
@@ -94,12 +97,18 @@ class DeviceGroupReader:
 
                                         # Only store target attributes if there are any
                                         if target_attributes:
-                                            tgroup_config['target_attributes'][target] = target_attributes
+                                            tgroup_config["target_attributes"][
+                                                target
+                                            ] = target_attributes
 
-                            group_config['target_groups'][tgroup_name] = TargetGroupConfig.from_config_dict(
-                                tgroup_name, tgroup_config
+                            group_config["target_groups"][tgroup_name] = (
+                                TargetGroupConfig.from_config_dict(
+                                    tgroup_name, tgroup_config
+                                )
                             )
 
-                device_groups[group_name] = DeviceGroupConfig.from_config_dict(group_name, group_config)
+                device_groups[group_name] = DeviceGroupConfig.from_config_dict(
+                    group_name, group_config
+                )
 
         return device_groups

--- a/scstadmin/readers/target_reader.py
+++ b/scstadmin/readers/target_reader.py
@@ -13,6 +13,7 @@ from typing import Dict, Set, Optional
 from ..sysfs import SCSTSysfs
 from ..exceptions import SCSTError
 from ..config import DriverConfig, TargetConfig
+from ..constants import SCSTConstants
 
 
 class TargetReader:
@@ -21,13 +22,6 @@ class TargetReader:
     This class handles target discovery, driver attribute management, and
     LUN operations within the SCST configuration system.
     """
-
-    # Known driver attributes that should not be treated as targets during cleanup
-    DRIVER_ATTRIBUTES = {
-        'copy_manager': {'copy_manager_tgt', 'dif_capabilities', 'allow_not_connected_copy'},
-        'iscsi': {'link_local', 'isns_entity_name', 'internal_portal', 'trace_level',
-                  'open_state', 'version', 'iSNSServer', 'enabled', 'mgmt'}
-    }
 
     def __init__(self, sysfs: SCSTSysfs):
         self.sysfs = sysfs
@@ -376,7 +370,7 @@ class TargetReader:
             driver_config = {'targets': {}, 'attributes': {}}
 
             # Read driver attributes from live system (only non-default values)
-            driver_attrs = self.DRIVER_ATTRIBUTES.get(driver, set())
+            driver_attrs = SCSTConstants.DRIVER_ATTRIBUTES.get(driver, set())
             for attr_name in driver_attrs:
                 # Skip non-attribute entries
                 if attr_name in {self.sysfs.MGMT_INTERFACE, 'type', 'trace_level', 'open_state', 'version'}:
@@ -407,7 +401,7 @@ class TargetReader:
 
             # Read targets for this driver
             # Get known driver attributes to skip for target detection
-            driver_attrs_for_skip = self.DRIVER_ATTRIBUTES.get(driver, set())
+            driver_attrs_for_skip = SCSTConstants.DRIVER_ATTRIBUTES.get(driver, set())
             driver_attrs_for_skip.update({self.sysfs.MGMT_INTERFACE, self.sysfs.ENABLED_ATTR})  # Always skip these
 
             for target in self.sysfs.list_directory(driver_path):

--- a/scstadmin/readers/target_reader.py
+++ b/scstadmin/readers/target_reader.py
@@ -71,9 +71,9 @@ class TargetReader:
             - Driver vs target attribute distinction determines command format
         """
         result = {
-            'create_params': set(),        # Target creation parameters
-            'driver_attributes': set(),    # Driver-level mgmt attributes
-            'target_attributes': set()     # Target-level mgmt attributes
+            "create_params": set(),  # Target creation parameters
+            "driver_attributes": set(),  # Driver-level mgmt attributes
+            "target_attributes": set(),  # Target-level mgmt attributes
         }
 
         try:
@@ -91,7 +91,7 @@ class TargetReader:
                     for param in params_str.split(","):
                         param = param.strip()
                         if param:
-                            result['create_params'].add(param)
+                            result["create_params"].add(param)
 
                 elif "The following target driver attributes available:" in line:
                     _, attrs_str = line.split(":", 1)
@@ -99,7 +99,7 @@ class TargetReader:
                     for attr in attrs_str.split(","):
                         attr = attr.strip()
                         if attr:
-                            result['driver_attributes'].add(attr)
+                            result["driver_attributes"].add(attr)
 
                 elif "The following target attributes available:" in line:
                     _, attrs_str = line.split(":", 1)
@@ -107,7 +107,7 @@ class TargetReader:
                     for attr in attrs_str.split(","):
                         attr = attr.strip()
                         if attr:
-                            result['target_attributes'].add(attr)
+                            result["target_attributes"].add(attr)
 
         except SCSTError:
             # If we can't read mgmt interface, return empty sets
@@ -133,19 +133,23 @@ class TargetReader:
 
         return self._mgmt_cache[cache_key]
 
-    def _get_target_create_params(self, driver_name: str, target_attrs: Dict[str, str]) -> Dict[str, str]:
+    def _get_target_create_params(
+        self, driver_name: str, target_attrs: Dict[str, str]
+    ) -> Dict[str, str]:
         """Get target creation parameters from driver mgmt interface"""
         mgmt_info = self._get_target_mgmt_info(driver_name)
 
         # Return only attributes that are valid creation parameters
         create_params = {}
         for attr, value in target_attrs.items():
-            if attr in mgmt_info['create_params']:
+            if attr in mgmt_info["create_params"]:
                 create_params[attr] = value
 
         return create_params
 
-    def _get_lun_create_params(self, driver: str, target: str, lun_attrs: Dict[str, str]) -> Dict[str, str]:
+    def _get_lun_create_params(
+        self, driver: str, target: str, lun_attrs: Dict[str, str]
+    ) -> Dict[str, str]:
         """Get LUN assignment creation parameters from luns mgmt interface"""
         create_params = {}
 
@@ -189,7 +193,7 @@ class TargetReader:
             raw_stripped = raw_value.strip()
 
             # Check if it has the [key] suffix indicating non-default value
-            if raw_stripped.endswith('[key]'):
+            if raw_stripped.endswith("[key]"):
                 # Strip off the [key] suffix to get clean value
                 clean_value = raw_stripped[:-5].strip()
                 return clean_value
@@ -199,8 +203,9 @@ class TargetReader:
         except SCSTError:
             return None
 
-    def _get_current_target_attrs(self, driver: str, target_name: str,
-                                  filter_attrs: Optional[Set[str]] = None) -> Dict[str, str]:
+    def _get_current_target_attrs(
+        self, driver: str, target_name: str, filter_attrs: Optional[Set[str]] = None
+    ) -> Dict[str, str]:
         """Read current target attribute values for configuration comparison.
 
         Handles multi-value attributes (IncomingUser, etc.) and skips creation-time
@@ -227,12 +232,12 @@ class TargetReader:
                 for attr in filter_attrs:
                     # Skip creation-time-only params (can't be read/compared post-creation)
                     # Matches Perl scstladmin filterCreateAttributes(TRUE) behavior
-                    if attr in mgmt_info['create_params']:
+                    if attr in mgmt_info["create_params"]:
                         continue
 
                     # Multi-value attributes: IncomingUser, OutgoingUser, etc. can have multiple entries
                     # SCST stores as: IncomingUser, IncomingUser1, IncomingUser2, IncomingUser3...
-                    if attr in mgmt_info['target_attributes']:
+                    if attr in mgmt_info["target_attributes"]:
                         collected_values = []
 
                         # Phase 1: Try base attribute name (IncomingUser -> /sys/.../IncomingUser)
@@ -245,7 +250,9 @@ class TargetReader:
                         # Continue until we hit a non-existent numbered attribute
                         counter = 1
                         while True:
-                            numbered_attr_path = os.path.join(target_path, f"{attr}{counter}")
+                            numbered_attr_path = os.path.join(
+                                target_path, f"{attr}{counter}"
+                            )
                             value = self._safe_read_attribute(numbered_attr_path)
                             if value is not None:  # Attribute file exists
                                 if value:  # Non-empty value
@@ -256,7 +263,7 @@ class TargetReader:
 
                         # Store as semicolon-separated if multiple values
                         if collected_values:
-                            attrs[attr] = ';'.join(collected_values)
+                            attrs[attr] = ";".join(collected_values)
 
                     else:
                         # Regular attribute - read single file
@@ -271,7 +278,11 @@ class TargetReader:
                 # Read all attribute files in the target directory (fallback)
                 for item in os.listdir(target_path):
                     item_path = os.path.join(target_path, item)
-                    if not item.startswith('.') and item not in ['luns', 'ini_groups', 'sessions']:
+                    if not item.startswith(".") and item not in [
+                        "luns",
+                        "ini_groups",
+                        "sessions",
+                    ]:
                         value = self._safe_read_attribute(item_path)
                         if value is not None:
                             attrs[item] = value
@@ -282,7 +293,9 @@ class TargetReader:
     def _get_current_lun_device(self, driver: str, target: str, lun_number: str) -> str:
         """Get the device currently assigned to a LUN"""
         try:
-            device_path = f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/luns/{lun_number}/device"
+            device_path = (
+                f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/luns/{lun_number}/device"
+            )
             if os.path.exists(device_path) and os.path.islink(device_path):
                 # Follow the symlink to get the device name
                 link_target = os.readlink(device_path)
@@ -292,11 +305,15 @@ class TargetReader:
             pass
         return ""
 
-    def _get_current_group_lun_device(self, driver: str, target: str, group_name: str, lun_number: str) -> str:
+    def _get_current_group_lun_device(
+        self, driver: str, target: str, group_name: str, lun_number: str
+    ) -> str:
         """Get the device currently assigned to a group LUN"""
         try:
-            device_path = (f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups/"
-                           f"{group_name}/luns/{lun_number}/device")
+            device_path = (
+                f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups/"
+                f"{group_name}/luns/{lun_number}/device"
+            )
             if os.path.exists(device_path) and os.path.islink(device_path):
                 # Follow the symlink to get the device name
                 link_target = os.readlink(device_path)
@@ -306,15 +323,17 @@ class TargetReader:
             pass
         return ""
 
-    def _get_driver_attribute_default(self, driver_name: str, attr_name: str) -> Optional[str]:
+    def _get_driver_attribute_default(
+        self, driver_name: str, attr_name: str
+    ) -> Optional[str]:
         """Get the default value for a driver attribute"""
         # Known defaults for common attributes
         defaults = {
-            'iscsi': {
-                'iSNSServer': '\n',  # Reset to system default
-                'internal_portal': '\n',  # Reset to system default
-                'link_local': '1',  # Default is enabled
-                'trace_level': '0'  # Default trace level
+            "iscsi": {
+                "iSNSServer": "\n",  # Reset to system default
+                "internal_portal": "\n",  # Reset to system default
+                "link_local": "1",  # Default is enabled
+                "trace_level": "0",  # Default trace level
             }
         }
 
@@ -367,25 +386,31 @@ class TargetReader:
 
         for driver in self.sysfs.list_directory(targets_path):
             driver_path = f"{targets_path}/{driver}"
-            driver_config = {'targets': {}, 'attributes': {}}
+            driver_config = {"targets": {}, "attributes": {}}
 
             # Read driver attributes from live system (only non-default values)
             driver_attrs = SCSTConstants.DRIVER_ATTRIBUTES.get(driver, set())
             for attr_name in driver_attrs:
                 # Skip non-attribute entries
-                if attr_name in {self.sysfs.MGMT_INTERFACE, 'type', 'trace_level', 'open_state', 'version'}:
+                if attr_name in {
+                    self.sysfs.MGMT_INTERFACE,
+                    "type",
+                    "trace_level",
+                    "open_state",
+                    "version",
+                }:
                     continue
 
                 attr_path = f"{driver_path}/{attr_name}"
                 if self.sysfs.valid_path(attr_path):
                     attr_value = self._read_attribute_if_non_default(attr_path)
                     if attr_value is not None:
-                        driver_config['attributes'][attr_name] = attr_value
+                        driver_config["attributes"][attr_name] = attr_value
 
             # Read driver mgmt attributes (IncomingUser, OutgoingUser, etc.)
             # These are dynamically created via add_attribute commands
             mgmt_info = self._get_target_mgmt_info(driver)
-            driver_mgmt_attrs = mgmt_info.get('driver_attributes', set())
+            driver_mgmt_attrs = mgmt_info.get("driver_attributes", set())
             for attr_name in driver_mgmt_attrs:
                 # Use glob to find all variants (IncomingUser, IncomingUser1, IncomingUser2, etc.)
                 # Numbered variants may have gaps (e.g., IncomingUser, IncomingUser2, IncomingUser5)
@@ -397,12 +422,14 @@ class TargetReader:
 
                 # Store as semicolon-separated if multiple values
                 if collected_values:
-                    driver_config['attributes'][attr_name] = ';'.join(collected_values)
+                    driver_config["attributes"][attr_name] = ";".join(collected_values)
 
             # Read targets for this driver
             # Get known driver attributes to skip for target detection
             driver_attrs_for_skip = SCSTConstants.DRIVER_ATTRIBUTES.get(driver, set())
-            driver_attrs_for_skip.update({self.sysfs.MGMT_INTERFACE, self.sysfs.ENABLED_ATTR})  # Always skip these
+            driver_attrs_for_skip.update(
+                {self.sysfs.MGMT_INTERFACE, self.sysfs.ENABLED_ATTR}
+            )  # Always skip these
 
             for target in self.sysfs.list_directory(driver_path):
                 if target not in driver_attrs_for_skip:
@@ -411,18 +438,23 @@ class TargetReader:
                     if os.path.isdir(target_path):
                         # Verify it's a real target by checking for target-specific subdirectories
                         has_luns = self.sysfs.valid_path(f"{target_path}/luns")
-                        has_ini_groups = self.sysfs.valid_path(f"{target_path}/ini_groups")
+                        has_ini_groups = self.sysfs.valid_path(
+                            f"{target_path}/ini_groups"
+                        )
                         has_sessions = self.sysfs.valid_path(f"{target_path}/sessions")
 
                         if has_luns or has_ini_groups or has_sessions:
                             # Create TargetConfig object for this target
                             target_config_dict = {
-                                'luns': {},
-                                'groups': {},
-                                'attributes': {}
+                                "luns": {},
+                                "groups": {},
+                                "attributes": {},
                             }
-                            driver_config['targets'][target] = TargetConfig.from_config_dict(
-                                target, target_config_dict)
+                            driver_config["targets"][target] = (
+                                TargetConfig.from_config_dict(
+                                    target, target_config_dict
+                                )
+                            )
 
             # Create DriverConfig object from collected data
             drivers[driver] = DriverConfig.from_config_dict(driver, driver_config)

--- a/scstadmin/sysfs.py
+++ b/scstadmin/sysfs.py
@@ -53,9 +53,9 @@ class SCSTSysfs:
     SCST_QUEUE_RES = f"{SCST_ROOT}/last_sysfs_mgmt_res"
 
     # SCST interface constants
-    MGMT_INTERFACE = 'mgmt'
-    ENABLED_ATTR = 'enabled'
-    HANDLER_SYSTEM_ATTRS = {'mgmt', 'type', 'trace_level'}
+    MGMT_INTERFACE = "mgmt"
+    ENABLED_ATTR = "enabled"
+    HANDLER_SYSTEM_ATTRS = {"mgmt", "type", "trace_level"}
 
     def __init__(self, timeout: int = SCSTConstants.DEFAULT_TIMEOUT):
         self.timeout = timeout
@@ -66,11 +66,8 @@ class SCSTSysfs:
         return os.path.exists(path) and os.access(path, os.R_OK)
 
     def write_sysfs(
-            self,
-            path: str,
-            data: str,
-            check_result: bool = True,
-            force_flush: bool = False) -> bool:
+        self, path: str, data: str, check_result: bool = True, force_flush: bool = False
+    ) -> bool:
         """Write data to a sysfs file with comprehensive error handling.
 
         This is the core method for all SCST sysfs operations. It validates
@@ -97,10 +94,10 @@ class SCSTSysfs:
                 raise SCSTError(f"No write permission for: {path}")
 
             # Clean up data representation for logging
-            data_repr = repr(data) if '\n' in data or not data.strip() else data
+            data_repr = repr(data) if "\n" in data or not data.strip() else data
             self.logger.debug("Writing %s to %s", data_repr, path)
 
-            with open(path, 'w') as f:
+            with open(path, "w") as f:
                 f.write(data)
                 if force_flush:
                     f.flush()
@@ -113,7 +110,9 @@ class SCSTSysfs:
         except PermissionError:
             raise SCSTError(f"Permission denied writing to {path}")
         except OSError as e:
-            if e.errno == SCSTConstants.EAGAIN_ERRNO:  # Resource temporarily unavailable
+            if (
+                e.errno == SCSTConstants.EAGAIN_ERRNO
+            ):  # Resource temporarily unavailable
                 if check_result:
                     return self._wait_for_completion()
                 return True
@@ -135,7 +134,7 @@ class SCSTSysfs:
             if not self.valid_path(path):
                 raise SCSTError(f"Cannot read from {path}")
 
-            with open(path, 'r') as f:
+            with open(path, "r") as f:
                 return f.read().strip()
 
         except OSError as e:
@@ -160,10 +159,10 @@ class SCSTSysfs:
             if not self.valid_path(path):
                 raise SCSTError(f"Cannot read from {path}")
 
-            with open(path, 'r') as f:
+            with open(path, "r") as f:
                 # Read only the first line and strip trailing newline
                 # This handles SCST's pattern where non-default values have '\n[key]' appended
-                return f.readline().rstrip('\n')
+                return f.readline().rstrip("\n")
 
         except OSError as e:
             raise SCSTError(f"Error reading from {path}: {e}")
@@ -197,12 +196,13 @@ class SCSTSysfs:
         try:
             if not self.valid_path(path):
                 return []
-            return [f for f in os.listdir(path) if not f.startswith('.')]
+            return [f for f in os.listdir(path) if not f.startswith(".")]
         except OSError:
             return []
 
-    def is_valid_sysfs_directory(self, base_path: str, item_name: str,
-                                 exclude_mgmt: bool = True) -> bool:
+    def is_valid_sysfs_directory(
+        self, base_path: str, item_name: str, exclude_mgmt: bool = True
+    ) -> bool:
         """Check if an item represents a valid SCST sysfs directory.
         This method validates that an item within a sysfs directory is:
         1. Actually a directory (not a file/attribute)
@@ -228,8 +228,9 @@ class SCSTSysfs:
         item_path = os.path.join(base_path, item_name)
         return os.path.isdir(item_path)
 
-    def mgmt_operation(self, mgmt_path: str, command: str, item: str,
-                       success_msg: str, error_msg: str) -> bool:
+    def mgmt_operation(
+        self, mgmt_path: str, command: str, item: str, success_msg: str, error_msg: str
+    ) -> bool:
         """Generic method for mgmt interface operations (add/del/create)
         Args:
             mgmt_path: Path to the mgmt interface file

--- a/scstadmin/writers/__init__.py
+++ b/scstadmin/writers/__init__.py
@@ -11,8 +11,4 @@ from .device_writer import DeviceWriter
 from .target_writer import TargetWriter
 from .group_writer import GroupWriter
 
-__all__ = [
-    'DeviceWriter',
-    'TargetWriter',
-    'GroupWriter'
-]
+__all__ = ["DeviceWriter", "TargetWriter", "GroupWriter"]

--- a/scstadmin/writers/device_writer.py
+++ b/scstadmin/writers/device_writer.py
@@ -3,6 +3,7 @@ Device Writer for SCST Administration
 
 This module handles device-specific write operations for SCST configuration.
 """
+
 import logging
 from typing import Dict
 
@@ -18,14 +19,16 @@ class DeviceWriter:
     def __init__(self, sysfs: SCSTSysfs, config_reader=None, logger=None):
         self.sysfs = sysfs
         self.config_reader = config_reader
-        self.logger = logger or logging.getLogger('scstadmin.writers.device')
+        self.logger = logger or logging.getLogger("scstadmin.writers.device")
 
     def device_exists(self, handler: str, device_name: str) -> bool:
         """Check if a device already exists under a handler"""
         device_path = f"{self.sysfs.SCST_HANDLERS}/{handler}/{device_name}"
         return entity_exists(device_path)
 
-    def set_device_attributes(self, handler: str, device_name: str, attrs: Dict[str, str]) -> None:
+    def set_device_attributes(
+        self, handler: str, device_name: str, attrs: Dict[str, str]
+    ) -> None:
         """Set post-creation attributes on an existing device.
         Args:
             handler: SCST handler name
@@ -33,20 +36,36 @@ class DeviceWriter:
             attrs: Dictionary of attribute name/value pairs to set
         """
         for attr_name, attr_value in attrs.items():
-            attr_path = f"{self.sysfs.SCST_HANDLERS}/{handler}/{device_name}/{attr_name}"
+            attr_path = (
+                f"{self.sysfs.SCST_HANDLERS}/{handler}/{device_name}/{attr_name}"
+            )
             try:
                 self.sysfs.write_sysfs(attr_path, attr_value, check_result=False)
-                self.logger.debug("Set device attribute %s.%s = %s", device_name, attr_name, attr_value)
+                self.logger.debug(
+                    "Set device attribute %s.%s = %s",
+                    device_name,
+                    attr_name,
+                    attr_value,
+                )
             except SCSTError as e:
-                self.logger.warning("Failed to set device attribute %s.%s: %s", device_name, attr_name, e)
+                self.logger.warning(
+                    "Failed to set device attribute %s.%s: %s",
+                    device_name,
+                    attr_name,
+                    e,
+                )
 
     def remove_device(self, handler: str, device_name: str) -> None:
         """Remove an existing device."""
         try:
-            self.sysfs.write_sysfs(f"{self.sysfs.SCST_HANDLERS}/{handler}/mgmt",
-                                   f"del_device {device_name}")
+            self.sysfs.write_sysfs(
+                f"{self.sysfs.SCST_HANDLERS}/{handler}/mgmt",
+                f"del_device {device_name}",
+            )
         except SCSTError as e:
-            self.logger.warning("Failed to remove existing device %s: %s", device_name, e)
+            self.logger.warning(
+                "Failed to remove existing device %s: %s", device_name, e
+            )
             # Continue anyway - the creation might still work
 
     def remove_device_by_name(self, device_name: str) -> None:
@@ -58,14 +77,18 @@ class DeviceWriter:
                 devices = self.sysfs.list_directory(handler_path)
                 if device_name in devices:
                     handler_mgmt = f"{handler_path}/mgmt"
-                    self.sysfs.write_sysfs(
-                        handler_mgmt, f"del_device {device_name}")
+                    self.sysfs.write_sysfs(handler_mgmt, f"del_device {device_name}")
                     break
         except SCSTError as e:
             self.logger.warning("Failed to remove device %s: %s", device_name, e)
 
-    def create_device(self, handler: str, device_name: str,
-                      creation_params: Dict[str, str], post_creation_attrs: Dict[str, str]) -> None:
+    def create_device(
+        self,
+        handler: str,
+        device_name: str,
+        creation_params: Dict[str, str],
+        post_creation_attrs: Dict[str, str],
+    ) -> None:
         """Create a new SCST device with proper parameter sequencing.
 
         SCST device creation follows a two-phase process:
@@ -103,7 +126,7 @@ class DeviceWriter:
         # Handle cluster_mode specially - set it after t10_dev_id
         cluster_mode = None
         for key, value in creation_params.items():
-            if key == 'cluster_mode':
+            if key == "cluster_mode":
                 cluster_mode = value
             else:
                 params.append(f"{key}={value}")
@@ -124,8 +147,14 @@ class DeviceWriter:
         if post_creation_attrs:
             self.set_device_attributes(handler, device_name, post_creation_attrs)
 
-    def determine_device_action(self, handler: str, device_name: str, device_config: DeviceConfig,
-                                creation_params: Dict[str, str], post_creation_attrs: Dict[str, str]) -> ConfigAction:
+    def determine_device_action(
+        self,
+        handler: str,
+        device_name: str,
+        device_config: DeviceConfig,
+        creation_params: Dict[str, str],
+        post_creation_attrs: Dict[str, str],
+    ) -> ConfigAction:
         """Determine what action to take for an existing device.
 
         Matches Perl scstadmin behavior: checks if any [key]-marked creation attributes
@@ -137,14 +166,18 @@ class DeviceWriter:
             ConfigAction.RECREATE: Creation attributes differ, device must be recreated
         """
         # Get all possible creation parameters for this handler type
-        all_creation_params = device_config._CREATION_PARAMS if hasattr(device_config, '_CREATION_PARAMS') else set()
+        all_creation_params = (
+            device_config._CREATION_PARAMS
+            if hasattr(device_config, "_CREATION_PARAMS")
+            else set()
+        )
 
         # Read current attributes - check all creation params, not just ones in config
         # This matches Perl's behavior of checking ALL device attributes
         config_attrs_to_check = all_creation_params | set(post_creation_attrs.keys())
-        existing_device_attrs = self.config_reader._get_current_device_attrs(handler,
-                                                                             device_name,
-                                                                             config_attrs_to_check)
+        existing_device_attrs = self.config_reader._get_current_device_attrs(
+            handler, device_name, config_attrs_to_check
+        )
 
         # Check for [key]-marked creation attributes that exist in device but not in config
         # This matches Perl's compareToKeyAttribute() logic (lines 2949-2951)
@@ -155,11 +188,13 @@ class DeviceWriter:
                 try:
                     # Read full attribute content including [key] marker
                     full_content = self.sysfs.read_sysfs(attr_path)
-                    if '[key]' in full_content:
+                    if "[key]" in full_content:
                         # [key] attribute exists but not in config - must recreate device
                         self.logger.debug(
                             "Device %s has [key] creation attribute '%s' not in config, must recreate",
-                            device_name, attr_name)
+                            device_name,
+                            attr_name,
+                        )
                         return ConfigAction.RECREATE
                 except (SCSTError, OSError, IOError):
                     # Attribute doesn't exist or can't be read - that's fine
@@ -167,11 +202,15 @@ class DeviceWriter:
 
         # Check if creation-time attributes differ (requires device recreation)
         creation_attrs_differ = attrs_config_differs(
-            creation_params, existing_device_attrs, entity_type="Device creation")
+            creation_params, existing_device_attrs, entity_type="Device creation"
+        )
 
         # Check if post-creation attributes differ (can be updated in place)
         post_attrs_differ = attrs_config_differs(
-            post_creation_attrs, existing_device_attrs, entity_type="Device post-creation")
+            post_creation_attrs,
+            existing_device_attrs,
+            entity_type="Device post-creation",
+        )
 
         if not creation_attrs_differ and not post_attrs_differ:
             return ConfigAction.SKIP
@@ -188,7 +227,9 @@ class DeviceWriter:
         3. If device exists but only post-creation attributes differ → update in-place
         4. If device already matches configuration → skip it
         """
-        self.logger.debug("Applying device configurations. Found %s devices", len(config.devices))
+        self.logger.debug(
+            "Applying device configurations. Found %s devices", len(config.devices)
+        )
         for device_name, device_config in config.devices.items():
             handler = device_config.handler_type
 
@@ -199,17 +240,35 @@ class DeviceWriter:
             # Check if device already exists and determine required action
             if self.device_exists(handler, device_name):
                 action = self.determine_device_action(
-                    handler, device_name, device_config, creation_params, post_creation_attrs)
+                    handler,
+                    device_name,
+                    device_config,
+                    creation_params,
+                    post_creation_attrs,
+                )
                 if action == ConfigAction.SKIP:
-                    self.logger.debug("Device %s already exists with matching config, skipping", device_name)
+                    self.logger.debug(
+                        "Device %s already exists with matching config, skipping",
+                        device_name,
+                    )
                     continue
                 elif action == ConfigAction.UPDATE:
-                    self.logger.debug("Device %s exists, updating post-creation attributes only", device_name)
-                    self.set_device_attributes(handler, device_name, post_creation_attrs)
+                    self.logger.debug(
+                        "Device %s exists, updating post-creation attributes only",
+                        device_name,
+                    )
+                    self.set_device_attributes(
+                        handler, device_name, post_creation_attrs
+                    )
                     continue
                 elif action == ConfigAction.RECREATE:
-                    self.logger.debug("Device %s creation attributes differ, removing and recreating", device_name)
+                    self.logger.debug(
+                        "Device %s creation attributes differ, removing and recreating",
+                        device_name,
+                    )
                     self.remove_device(handler, device_name)
 
             # Device doesn't exist or needs recreation - create it
-            self.create_device(handler, device_name, creation_params, post_creation_attrs)
+            self.create_device(
+                handler, device_name, creation_params, post_creation_attrs
+            )

--- a/scstadmin/writers/target_writer.py
+++ b/scstadmin/writers/target_writer.py
@@ -3,6 +3,7 @@ Target Writer for SCST Administration
 
 This module handles target-specific write operations for SCST configuration.
 """
+
 import glob
 import os
 import time
@@ -25,9 +26,11 @@ class TargetWriter:
     def __init__(self, sysfs: SCSTSysfs, config_reader=None, logger=None):
         self.sysfs = sysfs
         self.config_reader = config_reader
-        self.logger = logger or logging.getLogger('scstadmin.writers.target')
+        self.logger = logger or logging.getLogger("scstadmin.writers.target")
 
-    def set_target_attributes(self, driver_name: str, target_name: str, attributes: Dict[str, str]) -> None:
+    def set_target_attributes(
+        self, driver_name: str, target_name: str, attributes: Dict[str, str]
+    ) -> None:
         """Set target attributes after creation using appropriate SCST management commands.
 
         SCST target attributes are configured through different mechanisms depending on
@@ -65,33 +68,57 @@ class TargetWriter:
         driver_mgmt = f"{self.sysfs.SCST_TARGETS}/{driver_name}/mgmt"
 
         for attr_name, attr_value in attributes.items():
-            if attr_name in mgmt_info['target_attributes']:
+            if attr_name in mgmt_info["target_attributes"]:
                 # Use mgmt command for target-level mgmt attributes (e.g., IncomingUser)
                 # Handle multiple values separated by semicolons
-                values = attr_value.split(';') if ';' in attr_value else [attr_value]
+                values = attr_value.split(";") if ";" in attr_value else [attr_value]
 
                 for value in values:
                     if value.strip():  # Skip empty values
                         try:
                             self.logger.debug(
                                 "Setting target mgmt attribute %s/%s.%s = %s",
-                                driver_name, target_name, attr_name, value.strip())
+                                driver_name,
+                                target_name,
+                                attr_name,
+                                value.strip(),
+                            )
                             command = f"add_target_attribute {target_name} {attr_name} {value.strip()}"
-                            self.sysfs.write_sysfs(driver_mgmt, command, check_result=False)
+                            self.sysfs.write_sysfs(
+                                driver_mgmt, command, check_result=False
+                            )
                         except SCSTError as e:
                             self.logger.warning(
                                 "Failed to set %s/%s.%s=%s via mgmt: %s",
-                                driver_name, target_name, attr_name, value.strip(), e)
+                                driver_name,
+                                target_name,
+                                attr_name,
+                                value.strip(),
+                                e,
+                            )
             else:
                 # Use direct file write for regular attributes
-                attr_path = f"{self.sysfs.SCST_TARGETS}/{driver_name}/{target_name}/{attr_name}"
+                attr_path = (
+                    f"{self.sysfs.SCST_TARGETS}/{driver_name}/{target_name}/{attr_name}"
+                )
                 try:
                     self.sysfs.write_sysfs(attr_path, attr_value, check_result=False)
                 except SCSTError as e:
-                    self.logger.warning("Failed to set %s/%s.%s: %s", driver_name, target_name, attr_name, e)
+                    self.logger.warning(
+                        "Failed to set %s/%s.%s: %s",
+                        driver_name,
+                        target_name,
+                        attr_name,
+                        e,
+                    )
 
-    def update_target_attributes(self, driver_name: str, target_name: str,
-                                 desired_attrs: Dict[str, str], current_attrs: Dict[str, str]) -> None:
+    def update_target_attributes(
+        self,
+        driver_name: str,
+        target_name: str,
+        desired_attrs: Dict[str, str],
+        current_attrs: Dict[str, str],
+    ) -> None:
         """Update target attributes with efficient change detection and proper SCST handling.
 
         Compares desired configuration against current sysfs values and updates only
@@ -137,42 +164,65 @@ class TargetWriter:
             attrs_to_update[attr_name] = desired_value
             self.logger.debug(
                 "Target attribute '%s' needs update: current='%s' -> desired='%s'",
-                attr_name, current_value, desired_value)
+                attr_name,
+                current_value,
+                desired_value,
+            )
 
         # Find mgmt-managed attributes that need to be removed
         # ONLY check attributes that are in mgmt_info['target_attributes'] - these are the only
         # ones we can actually remove. All other attributes are read-only or system-managed.
-        for attr_name in mgmt_info['target_attributes']:
-            if attr_name not in desired_attrs and current_attrs.get(attr_name) is not None:
+        for attr_name in mgmt_info["target_attributes"]:
+            if (
+                attr_name not in desired_attrs
+                and current_attrs.get(attr_name) is not None
+            ):
                 attrs_to_remove.append(attr_name)
                 current_val = current_attrs.get(attr_name)
                 self.logger.debug(
                     "Target mgmt attribute '%s' needs removal: current='%s' -> not in desired",
-                    attr_name, current_val)
+                    attr_name,
+                    current_val,
+                )
 
         # Remove mgmt attributes that should no longer exist
         if attrs_to_remove:
-            self.logger.debug("Removing %s target mgmt attributes for %s/%s",
-                              len(attrs_to_remove), driver_name, target_name)
+            self.logger.debug(
+                "Removing %s target mgmt attributes for %s/%s",
+                len(attrs_to_remove),
+                driver_name,
+                target_name,
+            )
             for attr_name in attrs_to_remove:
                 self._remove_target_mgmt_attribute(driver_name, target_name, attr_name)
 
         # Update the attributes that differ
         if attrs_to_update:
-            self.logger.debug("Updating %s target attributes for %s/%s", len(attrs_to_update), driver_name, target_name)
+            self.logger.debug(
+                "Updating %s target attributes for %s/%s",
+                len(attrs_to_update),
+                driver_name,
+                target_name,
+            )
 
             # For mgmt-managed attributes, we need to remove old values first
             for attr_name, desired_value in attrs_to_update.items():
-                if attr_name in mgmt_info['target_attributes']:
+                if attr_name in mgmt_info["target_attributes"]:
                     # Remove existing values for this attribute
-                    self._remove_target_mgmt_attribute(driver_name, target_name, attr_name)
+                    self._remove_target_mgmt_attribute(
+                        driver_name, target_name, attr_name
+                    )
 
             # Set the new values
             self.set_target_attributes(driver_name, target_name, attrs_to_update)
         elif not attrs_to_remove:
-            self.logger.debug("No target attribute updates needed for %s/%s", driver_name, target_name)
+            self.logger.debug(
+                "No target attribute updates needed for %s/%s", driver_name, target_name
+            )
 
-    def _remove_target_mgmt_attribute(self, driver_name: str, target_name: str, attr_name: str) -> None:
+    def _remove_target_mgmt_attribute(
+        self, driver_name: str, target_name: str, attr_name: str
+    ) -> None:
         """Remove all variants of a target management attribute using SCST mgmt commands.
         SCST management-controlled attributes (like IncomingUser, OutgoingUser) can exist
         in multiple variants:
@@ -240,10 +290,21 @@ class TargetWriter:
                     self.sysfs.write_sysfs(driver_mgmt, command, check_result=False)
                     self.logger.debug(
                         "Removed target mgmt attribute %s/%s.%s = %s",
-                        driver_name, target_name, attr_name, value)
+                        driver_name,
+                        target_name,
+                        attr_name,
+                        value,
+                    )
                 except SCSTError as e:
                     # Log warning but continue - might not exist or already removed
-                    self.logger.debug("Could not remove %s/%s.%s=%s: %s", driver_name, target_name, attr_name, value, e)
+                    self.logger.debug(
+                        "Could not remove %s/%s.%s=%s: %s",
+                        driver_name,
+                        target_name,
+                        attr_name,
+                        value,
+                        e,
+                    )
         except (OSError, IOError) as e:
             self.logger.debug("Error reading target attributes for removal: %s", e)
 
@@ -280,9 +341,9 @@ class TargetWriter:
             - Driver vs target attribute distinction determines command format
         """
         result = {
-            'create_params': set(),        # Target creation parameters
-            'driver_attributes': set(),    # Driver-level mgmt attributes
-            'target_attributes': set()     # Target-level mgmt attributes
+            "create_params": set(),  # Target creation parameters
+            "driver_attributes": set(),  # Driver-level mgmt attributes
+            "target_attributes": set(),  # Target-level mgmt attributes
         }
         try:
             driver_mgmt = f"{self.sysfs.SCST_TARGETS}/{driver_name}/mgmt"
@@ -298,27 +359,29 @@ class TargetWriter:
                     for param in params_str.split(","):
                         param = param.strip()
                         if param:
-                            result['create_params'].add(param)
+                            result["create_params"].add(param)
                 elif "The following target driver attributes available:" in line:
                     _, attrs_str = line.split(":", 1)
                     attrs_str = attrs_str.strip().rstrip(".")
                     for attr in attrs_str.split(","):
                         attr = attr.strip()
                         if attr:
-                            result['driver_attributes'].add(attr)
+                            result["driver_attributes"].add(attr)
                 elif "The following target attributes available:" in line:
                     _, attrs_str = line.split(":", 1)
                     attrs_str = attrs_str.strip().rstrip(".")
                     for attr in attrs_str.split(","):
                         attr = attr.strip()
                         if attr:
-                            result['target_attributes'].add(attr)
+                            result["target_attributes"].add(attr)
         except SCSTError:
             # If we can't read mgmt interface, return empty sets
             pass
         return result
 
-    def _direct_lun_assignments_differ(self, driver: str, target: str, target_config: 'TargetConfig') -> bool:
+    def _direct_lun_assignments_differ(
+        self, driver: str, target: str, target_config: "TargetConfig"
+    ) -> bool:
         """Check if current direct LUN assignments differ from desired configuration.
         Compares current direct target LUN assignments (under target/luns/) against
         the desired direct LUN configuration.
@@ -337,7 +400,9 @@ class TargetWriter:
             if os.path.exists(luns_path):
                 for lun_item in os.listdir(luns_path):
                     if self.sysfs.is_valid_sysfs_directory(luns_path, lun_item):
-                        device = self.config_reader._get_current_lun_device(driver, target, lun_item)
+                        device = self.config_reader._get_current_lun_device(
+                            driver, target, lun_item
+                        )
                         if device:
                             current_direct_luns[lun_item] = device
 
@@ -354,7 +419,9 @@ class TargetWriter:
             # If we can't read current state, assume they differ
             return True
 
-    def _group_lun_assignments_differ(self, driver: str, target: str, target_config: 'TargetConfig') -> bool:
+    def _group_lun_assignments_differ(
+        self, driver: str, target: str, target_config: "TargetConfig"
+    ) -> bool:
         """Check if initiator group LUN assignments need updating.
         Compares current vs desired LUN assignments within each group to determine
         if updates are needed for access control changes.
@@ -368,17 +435,22 @@ class TargetWriter:
             if os.path.exists(ini_groups_path):
                 for group_name in os.listdir(ini_groups_path):
                     group_path = os.path.join(ini_groups_path, group_name)
-                    if group_name != self.sysfs.MGMT_INTERFACE and os.path.isdir(group_path):
+                    if group_name != self.sysfs.MGMT_INTERFACE and os.path.isdir(
+                        group_path
+                    ):
                         group_luns_path = f"{ini_groups_path}/{group_name}/luns"
                         if os.path.exists(group_luns_path):
                             group_luns = {}
                             for lun_item in os.listdir(group_luns_path):
-                                if lun_item != self.sysfs.MGMT_INTERFACE and os.path.isdir(
-                                        os.path.join(group_luns_path, lun_item)):
-                                    device = self.config_reader._get_current_group_lun_device(driver,
-                                                                                              target,
-                                                                                              group_name,
-                                                                                              lun_item)
+                                if (
+                                    lun_item != self.sysfs.MGMT_INTERFACE
+                                    and os.path.isdir(
+                                        os.path.join(group_luns_path, lun_item)
+                                    )
+                                ):
+                                    device = self.config_reader._get_current_group_lun_device(
+                                        driver, target, group_name, lun_item
+                                    )
                                     if device:
                                         group_luns[lun_item] = device
                             if group_luns:
@@ -401,7 +473,9 @@ class TargetWriter:
             # If we can't read current state, assume they differ
             return True
 
-    def _group_assignments_differ(self, driver: str, target: str, target_config: 'TargetConfig') -> bool:
+    def _group_assignments_differ(
+        self, driver: str, target: str, target_config: "TargetConfig"
+    ) -> bool:
         """Check if current initiator group assignments differ from desired configuration.
         Performs comprehensive comparison of initiator group configuration including
         both group membership (which groups exist) and individual group configurations
@@ -436,7 +510,9 @@ class TargetWriter:
             groups_path = f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups"
             if os.path.exists(groups_path):
                 for group_item in os.listdir(groups_path):
-                    if group_item != self.sysfs.MGMT_INTERFACE and os.path.isdir(os.path.join(groups_path, group_item)):
+                    if group_item != self.sysfs.MGMT_INTERFACE and os.path.isdir(
+                        os.path.join(groups_path, group_item)
+                    ):
                         current_groups.add(group_item)
 
             # Get desired groups
@@ -450,14 +526,18 @@ class TargetWriter:
             for group_name in desired_groups:
                 if self._group_exists(driver, target, group_name):
                     group_config = target_config.groups[group_name]
-                    if not self._group_config_matches(driver, target, group_name, group_config):
+                    if not self._group_config_matches(
+                        driver, target, group_name, group_config
+                    ):
                         return True
             return False
         except (OSError, IOError):
             # If we can't read current state, assume they differ
             return True
 
-    def _update_target_groups(self, driver: str, target: str, target_config: 'TargetConfig') -> None:
+    def _update_target_groups(
+        self, driver: str, target: str, target_config: "TargetConfig"
+    ) -> None:
         """Update initiator groups for fine-grained client access control.
         Enables different client groups to see different devices or LUN mappings.
         Only updates groups that have actually changed for optimal performance.
@@ -473,50 +553,94 @@ class TargetWriter:
                 if self._group_config_matches(driver, target, group_name, group_config):
                     self.logger.debug(
                         "Group %s for %s/%s already exists with matching config, skipping",
-                        group_name, driver, target)
+                        group_name,
+                        driver,
+                        target,
+                    )
                     continue
                 else:
                     self.logger.debug(
                         "Group %s for %s/%s config differs, updating incrementally",
-                        group_name, driver, target)
+                        group_name,
+                        driver,
+                        target,
+                    )
                     # Update the group configuration incrementally
                     self._update_group_config(driver, target, group_name, group_config)
                     continue
             else:
                 # Group doesn't exist - create it
-                self.logger.debug("Group %s for %s/%s doesn't exist, creating", group_name, driver, target)
+                self.logger.debug(
+                    "Group %s for %s/%s doesn't exist, creating",
+                    group_name,
+                    driver,
+                    target,
+                )
 
             # Create the group if it doesn't exist
             try:
                 self.sysfs.write_sysfs(mgmt_path, f"create {group_name}")
-                self.logger.debug("Created group %s for %s/%s", group_name, driver, target)
+                self.logger.debug(
+                    "Created group %s for %s/%s", group_name, driver, target
+                )
             except SCSTError:
                 pass  # Group might already exist
 
             # Add initiators to the group
-            group_initiators_path = (f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups/"
-                                     f"{group_name}/initiators/mgmt")
+            group_initiators_path = (
+                f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups/"
+                f"{group_name}/initiators/mgmt"
+            )
             for initiator in group_config.initiators:  # InitiatorGroupConfig object
                 try:
                     # Remove config file escape characters for sysfs
-                    clean_initiator = initiator.replace('\\#', '#').replace('\\*', '*')
-                    self.sysfs.write_sysfs(group_initiators_path, f"add {clean_initiator}")
-                    self.logger.debug("Added initiator %s to group %s", clean_initiator, group_name)
+                    clean_initiator = initiator.replace("\\#", "#").replace("\\*", "*")
+                    self.sysfs.write_sysfs(
+                        group_initiators_path, f"add {clean_initiator}"
+                    )
+                    self.logger.debug(
+                        "Added initiator %s to group %s", clean_initiator, group_name
+                    )
                 except SCSTError as e:
-                    self.logger.warning("Failed to add initiator %s to group %s: %s", clean_initiator, group_name, e)
+                    self.logger.warning(
+                        "Failed to add initiator %s to group %s: %s",
+                        clean_initiator,
+                        group_name,
+                        e,
+                    )
 
             # Add LUN assignments to the group
             group_luns_path = f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups/{group_name}/luns/mgmt"
-            for lun_number, lun_config in group_config.luns.items():  # InitiatorGroupConfig object
+            for (
+                lun_number,
+                lun_config,
+            ) in group_config.luns.items():  # InitiatorGroupConfig object
                 lun_device = lun_config.device  # Extract device name from LunConfig
                 try:
-                    self.sysfs.write_sysfs(group_luns_path, f"add {lun_device} {lun_number}")
-                    self.logger.debug("Added LUN %s (%s) to group %s", lun_number, lun_device, group_name)
+                    self.sysfs.write_sysfs(
+                        group_luns_path, f"add {lun_device} {lun_number}"
+                    )
+                    self.logger.debug(
+                        "Added LUN %s (%s) to group %s",
+                        lun_number,
+                        lun_device,
+                        group_name,
+                    )
                 except SCSTError as e:
-                    self.logger.warning("Failed to add LUN %s to group %s: %s", lun_number, group_name, e)
+                    self.logger.warning(
+                        "Failed to add LUN %s to group %s: %s",
+                        lun_number,
+                        group_name,
+                        e,
+                    )
 
-    def _update_group_config(self, driver: str, target: str, group_name: str,
-                             group_config: 'InitiatorGroupConfig') -> None:
+    def _update_group_config(
+        self,
+        driver: str,
+        target: str,
+        group_name: str,
+        group_config: "InitiatorGroupConfig",
+    ) -> None:
         """Update initiator group membership and LUN assignments incrementally.
         Updates both initiator membership (which clients can access) and LUN assignments
         (which devices they see). Only changes what's actually different for performance.
@@ -525,12 +649,16 @@ class TargetWriter:
         """
         # Check if the group configuration actually needs updating
         if self._group_config_matches(driver, target, group_name, group_config):
-            self.logger.debug("Group %s configuration already matches, skipping update", group_name)
+            self.logger.debug(
+                "Group %s configuration already matches, skipping update", group_name
+            )
             return
         self.logger.debug("Updating group %s configuration incrementally", group_name)
 
         # For now, implement basic updates by checking what differs
-        group_path = f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups/{group_name}"
+        group_path = (
+            f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups/{group_name}"
+        )
 
         # Phase 1: Update initiator membership (sysfs: ini_groups/{group}/initiators/{name})
         existing_initiators = set()
@@ -539,22 +667,25 @@ class TargetWriter:
             try:
                 for initiator_file in os.listdir(initiators_path):
                     if initiator_file != self.sysfs.MGMT_INTERFACE and os.path.isfile(
-                            os.path.join(initiators_path, initiator_file)):
+                        os.path.join(initiators_path, initiator_file)
+                    ):
                         existing_initiators.add(initiator_file)
             except (OSError, IOError):
                 pass
         desired_initiators = set(group_config.initiators)
         # Handle config file escaping: \\# and \\* in config become # and * in sysfs
-        normalized_existing = {init.replace('\\', '') for init in existing_initiators}
-        normalized_desired = {init.replace('\\', '') for init in desired_initiators}
+        normalized_existing = {init.replace("\\", "") for init in existing_initiators}
+        normalized_desired = {init.replace("\\", "") for init in desired_initiators}
         # Add missing initiators
         missing_initiators = normalized_desired - normalized_existing
         for initiator in missing_initiators:
             group_initiators_mgmt = f"{group_path}/initiators/mgmt"
             self.sysfs.mgmt_operation(
-                group_initiators_mgmt, "add", initiator,
+                group_initiators_mgmt,
+                "add",
+                initiator,
                 f"Added initiator {initiator} to group {group_name}",
-                f"Failed to add initiator {initiator} to group {group_name}"
+                f"Failed to add initiator {initiator} to group {group_name}",
             )
 
         # Remove extra initiators
@@ -562,16 +693,23 @@ class TargetWriter:
         for initiator in extra_initiators:
             group_initiators_mgmt = f"{group_path}/initiators/mgmt"
             self.sysfs.mgmt_operation(
-                group_initiators_mgmt, "del", initiator,
+                group_initiators_mgmt,
+                "del",
+                initiator,
                 f"Removed initiator {initiator} from group {group_name}",
-                f"Failed to remove initiator {initiator} from group {group_name}"
+                f"Failed to remove initiator {initiator} from group {group_name}",
             )
 
         # Update LUN assignments within the group
         self._update_group_lun_assignments(driver, target, group_name, group_config)
 
-    def _update_group_lun_assignments(self, driver: str, target: str, group_name: str,
-                                      group_config: 'InitiatorGroupConfig') -> None:
+    def _update_group_lun_assignments(
+        self,
+        driver: str,
+        target: str,
+        group_name: str,
+        group_config: "InitiatorGroupConfig",
+    ) -> None:
         """Update LUN-to-device assignments for an initiator group.
         Enables access control by allowing different groups to see different devices
         or the same devices at different LUN numbers. Only updates assignments that
@@ -579,7 +717,9 @@ class TargetWriter:
         Args:
             group_config: InitiatorGroupConfig object with luns property
         """
-        group_luns_path = f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups/{group_name}/luns"
+        group_luns_path = (
+            f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups/{group_name}/luns"
+        )
         group_luns_mgmt = f"{group_luns_path}/mgmt"
 
         # Read current LUN assignments from sysfs: /sys/.../ini_groups/{group}/luns/{lun_num}/
@@ -587,8 +727,12 @@ class TargetWriter:
         if os.path.exists(group_luns_path):
             try:
                 for lun_item in os.listdir(group_luns_path):
-                    if lun_item != self.sysfs.MGMT_INTERFACE and os.path.isdir(os.path.join(group_luns_path, lun_item)):
-                        device = self.config_reader._get_current_group_lun_device(driver, target, group_name, lun_item)
+                    if lun_item != self.sysfs.MGMT_INTERFACE and os.path.isdir(
+                        os.path.join(group_luns_path, lun_item)
+                    ):
+                        device = self.config_reader._get_current_group_lun_device(
+                            driver, target, group_name, lun_item
+                        )
                         if device:
                             current_group_luns[lun_item] = device
             except (OSError, IOError):
@@ -606,9 +750,16 @@ class TargetWriter:
         for lun_number in luns_to_remove:
             try:
                 self.sysfs.write_sysfs(group_luns_mgmt, f"del {lun_number}")
-                self.logger.debug("Removed LUN %s from group %s", lun_number, group_name)
+                self.logger.debug(
+                    "Removed LUN %s from group %s", lun_number, group_name
+                )
             except SCSTError as e:
-                self.logger.warning("Failed to remove LUN %s from group %s: %s", lun_number, group_name, e)
+                self.logger.warning(
+                    "Failed to remove LUN %s from group %s: %s",
+                    lun_number,
+                    group_name,
+                    e,
+                )
 
         # Add or update LUNs that should exist
         for lun_number, device in desired_group_luns.items():
@@ -616,36 +767,69 @@ class TargetWriter:
             if current_device != device:
                 # LUN doesn't exist or has wrong device - add/update it
                 try:
-                    self.sysfs.write_sysfs(group_luns_mgmt, f"add {device} {lun_number}")
+                    self.sysfs.write_sysfs(
+                        group_luns_mgmt, f"add {device} {lun_number}"
+                    )
                     if current_device:
                         self.logger.debug(
                             "Updated LUN %s in group %s: %s → %s",
-                            lun_number, group_name, current_device, device)
+                            lun_number,
+                            group_name,
+                            current_device,
+                            device,
+                        )
                     else:
-                        self.logger.debug("Added LUN %s to group %s: %s", lun_number, group_name, device)
+                        self.logger.debug(
+                            "Added LUN %s to group %s: %s",
+                            lun_number,
+                            group_name,
+                            device,
+                        )
                 except SCSTError as e:
-                    self.logger.warning("Failed to add LUN %s (%s) to group %s: %s", lun_number, device, group_name, e)
+                    self.logger.warning(
+                        "Failed to add LUN %s (%s) to group %s: %s",
+                        lun_number,
+                        device,
+                        group_name,
+                        e,
+                    )
 
-    def _set_lun_attributes(self, driver: str, target: str, lun_number: str, attributes: Dict[str, str]) -> None:
+    def _set_lun_attributes(
+        self, driver: str, target: str, lun_number: str, attributes: Dict[str, str]
+    ) -> None:
         """Set LUN attributes after assignment"""
         for attr_name, attr_value in attributes.items():
             attr_path = f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/luns/{lun_number}/{attr_name}"
             try:
                 self.sysfs.write_sysfs(attr_path, attr_value, check_result=False)
             except SCSTError as e:
-                self.logger.warning("Failed to set %s/%s/lun%s.%s: %s", driver, target, lun_number, attr_name, e)
+                self.logger.warning(
+                    "Failed to set %s/%s/lun%s.%s: %s",
+                    driver,
+                    target,
+                    lun_number,
+                    attr_name,
+                    e,
+                )
 
     def _target_exists(self, driver: str, target_name: str) -> bool:
         """Check if a target already exists under a driver"""
         target_path = f"{self.sysfs.SCST_TARGETS}/{driver}/{target_name}"
         return entity_exists(target_path)
 
-    def _target_config_differs(self, desired_attrs: Dict[str, str],
-                               current_attrs: Dict[str, str],
-                               removable_attrs: Optional[set] = None) -> bool:
+    def _target_config_differs(
+        self,
+        desired_attrs: Dict[str, str],
+        current_attrs: Dict[str, str],
+        removable_attrs: Optional[set] = None,
+    ) -> bool:
         """Compare desired target configuration with current configuration"""
-        return attrs_config_differs(desired_attrs, current_attrs, removable_attrs=removable_attrs,
-                                    entity_type="Target")
+        return attrs_config_differs(
+            desired_attrs,
+            current_attrs,
+            removable_attrs=removable_attrs,
+            entity_type="Target",
+        )
 
     def _lun_exists(self, driver: str, target: str, lun_number: str) -> bool:
         """Check if a LUN already exists for a target"""
@@ -654,11 +838,18 @@ class TargetWriter:
 
     def _group_exists(self, driver: str, target: str, group_name: str) -> bool:
         """Check if an initiator group already exists for a target"""
-        group_path = f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups/{group_name}"
+        group_path = (
+            f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups/{group_name}"
+        )
         return entity_exists(group_path)
 
-    def _group_config_matches(self, driver: str, target: str, group_name: str,
-                              group_config: 'InitiatorGroupConfig') -> bool:
+    def _group_config_matches(
+        self,
+        driver: str,
+        target: str,
+        group_name: str,
+        group_config: "InitiatorGroupConfig",
+    ) -> bool:
         """Check if existing initiator group configuration matches desired configuration.
         Compares current initiator group settings in sysfs against desired configuration.
         Checks both initiator list and LUN assignments within the group.
@@ -676,7 +867,9 @@ class TargetWriter:
             - Returns False on any sysfs read errors for safety
         """
         try:
-            group_path = f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups/{group_name}"
+            group_path = (
+                f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups/{group_name}"
+            )
             if not os.path.exists(group_path):
                 return False
 
@@ -686,16 +879,22 @@ class TargetWriter:
             if os.path.exists(initiators_path):
                 try:
                     for initiator_file in os.listdir(initiators_path):
-                        if initiator_file != self.sysfs.MGMT_INTERFACE and os.path.isfile(
-                                os.path.join(initiators_path, initiator_file)):
+                        if (
+                            initiator_file != self.sysfs.MGMT_INTERFACE
+                            and os.path.isfile(
+                                os.path.join(initiators_path, initiator_file)
+                            )
+                        ):
                             existing_initiators.add(initiator_file)
                 except (OSError, IOError):
                     pass
             desired_initiators = set(group_config.initiators)
 
             # Normalize both sets to handle backslash escaping differences
-            normalized_existing = {init.replace('\\', '') for init in existing_initiators}
-            normalized_desired = {init.replace('\\', '') for init in desired_initiators}
+            normalized_existing = {
+                init.replace("\\", "") for init in existing_initiators
+            }
+            normalized_desired = {init.replace("\\", "") for init in desired_initiators}
             if normalized_existing != normalized_desired:
                 return False
 
@@ -718,7 +917,7 @@ class TargetWriter:
         except (OSError, IOError):
             return False
 
-    def apply_config_assignments(self, config: 'SCSTConfig') -> None:
+    def apply_config_assignments(self, config: "SCSTConfig") -> None:
         """Apply target configurations with optimized incremental updates.
 
         Creates targets, updates attributes, and configures LUN/group assignments.
@@ -738,60 +937,106 @@ class TargetWriter:
                     mgmt_info = self.config_reader._get_target_mgmt_info(driver_name)
 
                     # Read attributes: config attrs + mgmt-managed attrs (to check for removal)
-                    config_attrs_to_check = set(target_attrs.keys()) | mgmt_info['target_attributes']
-                    existing_target_attrs = self.config_reader._get_current_target_attrs(
-                        driver_name, target_name, config_attrs_to_check)
+                    config_attrs_to_check = (
+                        set(target_attrs.keys()) | mgmt_info["target_attributes"]
+                    )
+                    existing_target_attrs = (
+                        self.config_reader._get_current_target_attrs(
+                            driver_name, target_name, config_attrs_to_check
+                        )
+                    )
 
                     # Filter out creation-time parameters (can't be changed post-creation)
                     # Examples: InitiatorName, TargetName for iSCSI targets
-                    settable_target_attrs = {k: v for k, v in target_attrs.items()
-                                             if k not in mgmt_info['create_params']}
+                    settable_target_attrs = {
+                        k: v
+                        for k, v in target_attrs.items()
+                        if k not in mgmt_info["create_params"]
+                    }
                     attrs_differ = self._target_config_differs(
-                        settable_target_attrs, existing_target_attrs,
-                        removable_attrs=mgmt_info['target_attributes'])
+                        settable_target_attrs,
+                        existing_target_attrs,
+                        removable_attrs=mgmt_info["target_attributes"],
+                    )
 
                     # Phase 1: Update target attributes if they've changed
                     if attrs_differ:
-                        self.logger.debug("Target attributes differ for %s/%s, updating", driver_name, target_name)
-                        self.update_target_attributes(driver_name, target_name, settable_target_attrs,
-                                                      existing_target_attrs)
+                        self.logger.debug(
+                            "Target attributes differ for %s/%s, updating",
+                            driver_name,
+                            target_name,
+                        )
+                        self.update_target_attributes(
+                            driver_name,
+                            target_name,
+                            settable_target_attrs,
+                            existing_target_attrs,
+                        )
 
                     # Phase 2: Check all assignment types (independent of attribute changes)
                     # Three types of LUN/access assignments that can change independently:
-                    direct_luns_differ = self._direct_lun_assignments_differ(driver_name, target_name,
-                                                                             target_config)  # Target-level LUNs
+                    direct_luns_differ = self._direct_lun_assignments_differ(
+                        driver_name, target_name, target_config
+                    )  # Target-level LUNs
 
-                    group_luns_differ = self._group_lun_assignments_differ(driver_name, target_name,
-                                                                           target_config)  # Group-specific LUNs
+                    group_luns_differ = self._group_lun_assignments_differ(
+                        driver_name, target_name, target_config
+                    )  # Group-specific LUNs
 
-                    groups_differ = self._group_assignments_differ(driver_name, target_name,
-                                                                   target_config)  # Group membership
+                    groups_differ = self._group_assignments_differ(
+                        driver_name, target_name, target_config
+                    )  # Group membership
 
                     if direct_luns_differ:
-                        self.logger.debug("Direct LUN assignments differ for %s/%s, updating", driver_name, target_name)
-                        self.apply_lun_assignments(driver_name, target_name, target_config)
+                        self.logger.debug(
+                            "Direct LUN assignments differ for %s/%s, updating",
+                            driver_name,
+                            target_name,
+                        )
+                        self.apply_lun_assignments(
+                            driver_name, target_name, target_config
+                        )
 
                     if group_luns_differ or groups_differ:
-                        self.logger.debug("Group assignments differ for %s/%s, updating", driver_name, target_name)
-                        self._update_target_groups(driver_name, target_name, target_config)
+                        self.logger.debug(
+                            "Group assignments differ for %s/%s, updating",
+                            driver_name,
+                            target_name,
+                        )
+                        self._update_target_groups(
+                            driver_name, target_name, target_config
+                        )
 
-                    if not (attrs_differ or direct_luns_differ or group_luns_differ or groups_differ):
+                    if not (
+                        attrs_differ
+                        or direct_luns_differ
+                        or group_luns_differ
+                        or groups_differ
+                    ):
                         self.logger.debug(
                             "Target %s/%s already exists with matching config, skipping",
-                            driver_name, target_name)
+                            driver_name,
+                            target_name,
+                        )
 
                     continue
 
                 # Create the target if it doesn't exist
-                creation_params = self.config_reader._get_target_create_params(driver_name, target_attrs)
+                creation_params = self.config_reader._get_target_create_params(
+                    driver_name, target_attrs
+                )
 
                 # For virtual targets (those with creation params like node_name),
                 # ensure hardware targets are enabled first
                 if creation_params:
-                    self.ensure_hardware_targets_enabled(driver_name, config.drivers[driver_name])
+                    self.ensure_hardware_targets_enabled(
+                        driver_name, config.drivers[driver_name]
+                    )
 
                 if creation_params:
-                    params_str = ';'.join([f"{k}={v}" for k, v in creation_params.items()])
+                    params_str = ";".join(
+                        [f"{k}={v}" for k, v in creation_params.items()]
+                    )
                     command = f"add_target {target_name} {params_str}"
                 else:
                     command = f"add_target {target_name}"
@@ -799,32 +1044,33 @@ class TargetWriter:
                 self.sysfs.write_sysfs(mgmt_path, command)
 
                 # Set remaining target attributes after creation
-                remaining_attrs = {k: v for k, v in target_attrs.items()
-                                   if k not in creation_params}
+                remaining_attrs = {
+                    k: v for k, v in target_attrs.items() if k not in creation_params
+                }
                 if remaining_attrs:
-                    self.set_target_attributes(driver_name, target_name, remaining_attrs)
+                    self.set_target_attributes(
+                        driver_name, target_name, remaining_attrs
+                    )
 
                 # Apply LUN assignments
-                self.apply_lun_assignments(
-                    driver_name, target_name, target_config)
+                self.apply_lun_assignments(driver_name, target_name, target_config)
 
                 # Apply group assignments
-                self.apply_group_assignments(
-                    driver_name, target_name, target_config)
+                self.apply_group_assignments(driver_name, target_name, target_config)
 
-    def cleanup_copy_manager_duplicates(self, config: 'SCSTConfig') -> None:
+    def cleanup_copy_manager_duplicates(self, config: "SCSTConfig") -> None:
         """Remove duplicate copy_manager LUN assignments to prevent conflicts.
 
         SCST copy_manager automatically creates LUNs but explicit config may specify
         different LUN numbers. Cleans up auto-created duplicates after explicit assignment.
         """
         # Early exit if no copy_manager driver configured
-        copy_manager_config = config.drivers.get('copy_manager')
+        copy_manager_config = config.drivers.get("copy_manager")
         if not copy_manager_config:
             return
 
         # Extract explicit LUN configuration from copy_manager_tgt
-        target_config = copy_manager_config.targets.get('copy_manager_tgt')
+        target_config = copy_manager_config.targets.get("copy_manager_tgt")
         explicit_luns = target_config.luns if target_config else {}
         if not explicit_luns:
             return  # No explicit LUNs configured, nothing to clean up
@@ -849,9 +1095,13 @@ class TargetWriter:
         try:
             luns_to_remove = []
             for lun_item in os.listdir(luns_path):
-                if lun_item != self.sysfs.MGMT_INTERFACE and os.path.isdir(f"{luns_path}/{lun_item}"):
+                if lun_item != self.sysfs.MGMT_INTERFACE and os.path.isdir(
+                    f"{luns_path}/{lun_item}"
+                ):
                     # Get device assigned to this LUN number
-                    device = self.config_reader._get_current_lun_device('copy_manager', 'copy_manager_tgt', lun_item)
+                    device = self.config_reader._get_current_lun_device(
+                        "copy_manager", "copy_manager_tgt", lun_item
+                    )
 
                     if device in explicit_devices:
                         # Check if this device should be at a different LUN number
@@ -862,7 +1112,10 @@ class TargetWriter:
                             expected = explicit_devices[device]
                             self.logger.debug(
                                 "Found duplicate LUN %s for device %s (expected: %s)",
-                                lun_item, device, expected)
+                                lun_item,
+                                device,
+                                expected,
+                            )
                     # If device is NOT in explicit config, leave it alone - copy_manager can have
                     # auto-created LUNs for devices not explicitly listed in the config
 
@@ -873,14 +1126,20 @@ class TargetWriter:
                     try:
                         # Management command: "del {lun_number}"
                         self.sysfs.write_sysfs(mgmt_path, f"del {lun_num}")
-                        self.logger.debug("Removed duplicate LUN %s from copy_manager_tgt", lun_num)
+                        self.logger.debug(
+                            "Removed duplicate LUN %s from copy_manager_tgt", lun_num
+                        )
                     except SCSTError as e:
-                        self.logger.warning("Failed to remove duplicate LUN %s: %s", lun_num, e)
+                        self.logger.warning(
+                            "Failed to remove duplicate LUN %s: %s", lun_num, e
+                        )
 
         except (OSError, IOError) as e:
             self.logger.warning("Failed to cleanup copy_manager duplicates: %s", e)
 
-    def ensure_hardware_targets_enabled(self, driver_name: str, driver_config: 'DriverConfig') -> None:
+    def ensure_hardware_targets_enabled(
+        self, driver_name: str, driver_config: "DriverConfig"
+    ) -> None:
         """Enable hardware targets that should be active according to configuration.
 
         Hardware targets (FC, SAS) require explicit enabling to become accessible.
@@ -928,24 +1187,33 @@ class TargetWriter:
                 # Default to disabled ('0') if not explicitly configured
                 target_config = driver_config.targets.get(target)
                 target_attrs = target_config.attributes if target_config else {}
-                should_be_enabled = target_attrs.get('enabled', '0') == '1'
+                should_be_enabled = target_attrs.get("enabled", "0") == "1"
 
                 # Enable hardware target if it should be enabled but currently isn't
-                if should_be_enabled and current_enabled != '1':
-                    self.logger.debug("Enabling hardware target %s/%s for virtual target creation", driver_name, target)
+                if should_be_enabled and current_enabled != "1":
+                    self.logger.debug(
+                        "Enabling hardware target %s/%s for virtual target creation",
+                        driver_name,
+                        target,
+                    )
                     try:
-                        self.sysfs.write_sysfs(enabled_path, '1', check_result=False)
+                        self.sysfs.write_sysfs(enabled_path, "1", check_result=False)
                     except SCSTError as e:
-                        self.logger.warning("Failed to enable hardware target %s/%s: %s", driver_name, target, e)
+                        self.logger.warning(
+                            "Failed to enable hardware target %s/%s: %s",
+                            driver_name,
+                            target,
+                            e,
+                        )
 
         except SCSTError as e:
-            self.logger.warning("Failed to check hardware targets for %s: %s", driver_name, e)
+            self.logger.warning(
+                "Failed to check hardware targets for %s: %s", driver_name, e
+            )
 
     def apply_lun_assignments(
-            self,
-            driver: str,
-            target: str,
-            target_config: Dict[str, Any]) -> None:
+        self, driver: str, target: str, target_config: Dict[str, Any]
+    ) -> None:
         """Apply direct LUN-to-device assignments for a target.
 
         Creates LUN assignments with proper parameter handling and device verification.
@@ -959,13 +1227,15 @@ class TargetWriter:
         # current_lun_devices: enables fast lookup of current device assignments without sysfs reads
         existing_lun_map = {}  # {device: lun_number}
         current_lun_devices = {}  # {lun_number: device}
-        if driver == 'copy_manager' and target == 'copy_manager_tgt':
+        if driver == "copy_manager" and target == "copy_manager_tgt":
             luns_dir = Path(self.sysfs.SCST_TARGETS) / driver / target / "luns"
             try:
                 for lun_path in luns_dir.iterdir():
                     existing_lun = lun_path.name
                     if existing_lun != self.sysfs.MGMT_INTERFACE and lun_path.is_dir():
-                        existing_device = self.config_reader._get_current_lun_device(driver, target, existing_lun)
+                        existing_device = self.config_reader._get_current_lun_device(
+                            driver, target, existing_lun
+                        )
                         if existing_device:
                             existing_lun_map[existing_device] = existing_lun
                             current_lun_devices[existing_lun] = existing_device
@@ -982,13 +1252,16 @@ class TargetWriter:
                 continue  # Skip empty device assignments
 
             # Special handling for copy_manager: check if device already has a LUN assigned elsewhere
-            if driver == 'copy_manager' and target == 'copy_manager_tgt':
+            if driver == "copy_manager" and target == "copy_manager_tgt":
                 existing_lun = existing_lun_map.get(device)
                 if existing_lun and existing_lun != lun_number:
                     # Device already assigned to different LUN, remove it first
                     self.logger.debug(
                         "Device %s already at LUN %s, removing before assigning to LUN %s",
-                        device, existing_lun, lun_number)
+                        device,
+                        existing_lun,
+                        lun_number,
+                    )
                     try:
                         self.sysfs.write_sysfs(luns_path, f"del {existing_lun}")
                         # Update maps since we removed it
@@ -996,64 +1269,101 @@ class TargetWriter:
                         if existing_lun in current_lun_devices:
                             del current_lun_devices[existing_lun]
                     except SCSTError as e:
-                        self.logger.warning("Failed to remove existing LUN %s: %s", existing_lun, e)
+                        self.logger.warning(
+                            "Failed to remove existing LUN %s: %s", existing_lun, e
+                        )
 
             # Optimization: check if LUN assignment already correct (avoid unnecessary operations)
             lun_exists = self._lun_exists(driver, target, lun_number)
             if lun_exists:
                 # For copy_manager, use cached device mapping; otherwise read from sysfs
-                if driver == 'copy_manager' and target == 'copy_manager_tgt':
+                if driver == "copy_manager" and target == "copy_manager_tgt":
                     current_device = current_lun_devices.get(lun_number, "")
                 else:
-                    current_device = self.config_reader._get_current_lun_device(driver, target, lun_number)
+                    current_device = self.config_reader._get_current_lun_device(
+                        driver, target, lun_number
+                    )
                 if current_device == device:
                     # LUN already correctly assigned, skip this LUN
                     self.logger.debug(
                         "LUN %s for %s/%s already assigned to correct device %s, skipping",
-                        lun_number, driver, target, device)
+                        lun_number,
+                        driver,
+                        target,
+                        device,
+                    )
                     continue
                 elif current_device == "":
                     # LUN exists but device symlink is broken/stale - must recreate assignment
                     self.logger.debug(
                         "LUN %s for %s/%s has broken device symlink, removing and recreating",
-                        lun_number, driver, target)
+                        lun_number,
+                        driver,
+                        target,
+                    )
                     try:
                         # Management command: "del {lun_number}"
                         self.sysfs.write_sysfs(luns_path, f"del {lun_number}")
                     except SCSTError as e:
-                        self.logger.warning("Failed to remove existing LUN %s for %s/%s: %s",
-                                            lun_number, driver, target, e)
+                        self.logger.warning(
+                            "Failed to remove existing LUN %s for %s/%s: %s",
+                            lun_number,
+                            driver,
+                            target,
+                            e,
+                        )
                         # Continue anyway - the new assignment might still work
                 else:
                     # LUN exists but points to wrong device - must recreate assignment
                     self.logger.debug(
                         "LUN %s for %s/%s assigned to different device (%s vs %s), removing and recreating",
-                        lun_number, driver, target, current_device, device)
+                        lun_number,
+                        driver,
+                        target,
+                        current_device,
+                        device,
+                    )
                     try:
                         # Management command: "del {lun_number}"
                         self.sysfs.write_sysfs(luns_path, f"del {lun_number}")
                     except SCSTError as e:
-                        self.logger.warning("Failed to remove existing LUN %s for %s/%s: %s",
-                                            lun_number, driver, target, e)
+                        self.logger.warning(
+                            "Failed to remove existing LUN %s for %s/%s: %s",
+                            lun_number,
+                            driver,
+                            target,
+                            e,
+                        )
                         # Continue anyway - the new assignment might still work
 
             # Separate creation-time vs post-creation LUN parameters
             # Some attributes must be set during LUN creation, others can be set afterward
             # Use cached create params if available (same for all LUNs with same driver/target)
             if not lun_create_params_cache:
-                lun_create_params_cache['params'] = self.config_reader._get_lun_create_params(
-                    driver, target, lun_config.attributes)
+                lun_create_params_cache["params"] = (
+                    self.config_reader._get_lun_create_params(
+                        driver, target, lun_config.attributes
+                    )
+                )
 
             # Filter for this LUN's specific create params
-            lun_create_params = {k: v for k, v in lun_config.attributes.items()
-                                 if k in lun_create_params_cache.get('params', {})}
-            lun_post_params = {k: v for k, v in lun_config.attributes.items()
-                               if k not in lun_create_params}
+            lun_create_params = {
+                k: v
+                for k, v in lun_config.attributes.items()
+                if k in lun_create_params_cache.get("params", {})
+            }
+            lun_post_params = {
+                k: v
+                for k, v in lun_config.attributes.items()
+                if k not in lun_create_params
+            }
 
             # Build SCST management command with creation-time parameters
             # Format: "add {device} {lun_number} param1=value1;param2=value2;"
             if lun_create_params:
-                params_str = ';'.join([f"{k}={v}" for k, v in lun_create_params.items()])
+                params_str = ";".join(
+                    [f"{k}={v}" for k, v in lun_create_params.items()]
+                )
                 command = f"add {device} {lun_number} {params_str};"
             else:
                 # Simple assignment with no creation parameters
@@ -1067,10 +1377,8 @@ class TargetWriter:
                 self._set_lun_attributes(driver, target, lun_number, lun_post_params)
 
     def apply_group_assignments(
-            self,
-            driver: str,
-            target: str,
-            target_config: Dict[str, Any]) -> None:
+        self, driver: str, target: str, target_config: Dict[str, Any]
+    ) -> None:
         """Apply initiator group configurations for access control.
 
         Creates groups with initiator membership and LUN assignments. Uses optimized
@@ -1086,30 +1394,46 @@ class TargetWriter:
                 if self._group_config_matches(driver, target, group_name, group_config):
                     self.logger.debug(
                         "Group %s for %s/%s already exists with matching config, skipping",
-                        group_name, driver, target)
+                        group_name,
+                        driver,
+                        target,
+                    )
                     continue  # Group already correctly configured
                 else:
-                    self.logger.debug("Group %s for %s/%s exists but config differs", group_name, driver, target)
+                    self.logger.debug(
+                        "Group %s for %s/%s exists but config differs",
+                        group_name,
+                        driver,
+                        target,
+                    )
 
             # Create initiator group (will be no-op if already exists)
             try:
                 # Management command: "create {group_name}"
                 self.sysfs.write_sysfs(mgmt_path, f"create {group_name}")
-                self.logger.debug("Created group %s for %s/%s", group_name, driver, target)
+                self.logger.debug(
+                    "Created group %s for %s/%s", group_name, driver, target
+                )
             except SCSTError:
                 pass  # Group creation might fail if already exists
 
             # Phase 1: Configure initiator membership within the group
             # Each group defines which clients (initiators) can access through this path
-            group_initiators_path = (f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups/"
-                                     f"{group_name}/initiators/mgmt")
+            group_initiators_path = (
+                f"{self.sysfs.SCST_TARGETS}/{driver}/{target}/ini_groups/"
+                f"{group_name}/initiators/mgmt"
+            )
             for initiator in group_config.initiators:  # InitiatorGroupConfig object
                 try:
                     # Handle config file escaping: \\# and \\* become # and * in sysfs
-                    clean_initiator = initiator.replace('\\#', '#').replace('\\*', '*')
+                    clean_initiator = initiator.replace("\\#", "#").replace("\\*", "*")
                     # Management command: "add {initiator_name}"
-                    self.sysfs.write_sysfs(group_initiators_path, f"add {clean_initiator}")
-                    self.logger.debug("Added initiator %s to group %s", clean_initiator, group_name)
+                    self.sysfs.write_sysfs(
+                        group_initiators_path, f"add {clean_initiator}"
+                    )
+                    self.logger.debug(
+                        "Added initiator %s to group %s", clean_initiator, group_name
+                    )
                 except SCSTError:
                     pass  # Initiator addition might fail if already exists
 
@@ -1120,12 +1444,19 @@ class TargetWriter:
                 device_name = lun_config.device  # LunConfig object
                 try:
                     # Management command: "add {device} {lun_number}"
-                    self.sysfs.write_sysfs(group_luns_path, f"add {device_name} {lun_number}")
-                    self.logger.debug("Added LUN %s (%s) to group %s", lun_number, device_name, group_name)
+                    self.sysfs.write_sysfs(
+                        group_luns_path, f"add {device_name} {lun_number}"
+                    )
+                    self.logger.debug(
+                        "Added LUN %s (%s) to group %s",
+                        lun_number,
+                        device_name,
+                        group_name,
+                    )
                 except SCSTError:
                     pass  # LUN assignment might fail if already exists
 
-    def apply_config_enable_targets(self, config: 'SCSTConfig') -> None:
+    def apply_config_enable_targets(self, config: "SCSTConfig") -> None:
         """Activate configured targets to begin serving storage to initiators.
 
         Targets must be explicitly enabled after configuration to start accepting
@@ -1133,44 +1464,50 @@ class TargetWriter:
         """
         for driver_name, driver_config in config.drivers.items():
             for target_name, target_config in driver_config.targets.items():
-                enabled = target_config.attributes.get('enabled', '0')
-                if enabled == '1':
-                    enabled_path = f"{self.sysfs.SCST_TARGETS}/{driver_name}/{target_name}/enabled"
+                enabled = target_config.attributes.get("enabled", "0")
+                if enabled == "1":
+                    enabled_path = (
+                        f"{self.sysfs.SCST_TARGETS}/{driver_name}/{target_name}/enabled"
+                    )
                     try:
                         # Avoid unnecessary sysfs writes for performance
                         current_value = self.sysfs.read_sysfs(enabled_path)
-                        if current_value != '1':
-                            self.sysfs.write_sysfs(enabled_path, '1', check_result=False)
+                        if current_value != "1":
+                            self.sysfs.write_sysfs(
+                                enabled_path, "1", check_result=False
+                            )
                     except SCSTError:
                         # Fallback: attempt enable even if current state unknown
                         try:
-                            self.sysfs.write_sysfs(enabled_path, '1', check_result=False)
+                            self.sysfs.write_sysfs(
+                                enabled_path, "1", check_result=False
+                            )
                         except SCSTError:
                             pass
 
-    def apply_config_enable_drivers(self, config: 'SCSTConfig') -> None:
+    def apply_config_enable_drivers(self, config: "SCSTConfig") -> None:
         """Activate SCST protocol drivers to accept initiator connections.
 
         Drivers like iSCSI, FC, and SRP must be enabled to process protocol-specific
         requests and present targets to the network.
         """
         for driver_name, driver_config in config.drivers.items():
-            enabled = driver_config.attributes.get('enabled', '0')
-            if enabled == '1':
+            enabled = driver_config.attributes.get("enabled", "0")
+            if enabled == "1":
                 enabled_path = f"{self.sysfs.SCST_TARGETS}/{driver_name}/enabled"
                 try:
                     # Avoid unnecessary sysfs writes for performance
                     current_value = self.sysfs.read_sysfs(enabled_path)
-                    if current_value != '1':
-                        self.sysfs.write_sysfs(enabled_path, '1', check_result=False)
+                    if current_value != "1":
+                        self.sysfs.write_sysfs(enabled_path, "1", check_result=False)
                 except SCSTError:
                     # Fallback: attempt enable even if current state unknown
                     try:
-                        self.sysfs.write_sysfs(enabled_path, '1', check_result=False)
+                        self.sysfs.write_sysfs(enabled_path, "1", check_result=False)
                     except SCSTError:
                         pass
 
-    def apply_config_driver_attributes(self, config: 'SCSTConfig') -> None:
+    def apply_config_driver_attributes(self, config: "SCSTConfig") -> None:
         """Configure protocol driver parameters for optimal performance and behavior.
 
         Sets driver-specific attributes like threading models, queue depths, and
@@ -1191,26 +1528,36 @@ class TargetWriter:
 
             # Get mgmt interface info to identify mgmt-controlled attributes
             mgmt_info = self.config_reader._get_target_mgmt_info(driver_name)
-            driver_mgmt_attrs = mgmt_info.get('driver_attributes', set())
+            driver_mgmt_attrs = mgmt_info.get("driver_attributes", set())
 
             # Apply configuration attributes (enabled handled separately for proper sequencing)
             for attr_name, attr_value in driver_config.attributes.items():
-                if attr_name == 'enabled':
+                if attr_name == "enabled":
                     continue  # Skip enabled - must be set after other attributes
 
                 # Check if this is a mgmt-controlled driver attribute
                 if attr_name in driver_mgmt_attrs:
                     # Use incremental update for driver mgmt attributes (matches Perl behavior)
                     # Compare current vs desired values and only add/remove what changed
-                    self._update_driver_mgmt_attribute(driver_name, attr_name, attr_value)
+                    self._update_driver_mgmt_attribute(
+                        driver_name, attr_name, attr_value
+                    )
                 else:
                     # Use direct sysfs write for regular attributes
                     attr_path = f"{driver_path}/{attr_name}"
 
                     # Skip read-only attributes to avoid errors
-                    if not os.access(attr_path, os.W_OK) if os.path.exists(attr_path) else True:
+                    if (
+                        not os.access(attr_path, os.W_OK)
+                        if os.path.exists(attr_path)
+                        else True
+                    ):
                         if os.path.exists(attr_path):
-                            self.logger.debug("Skipping non-writable attribute %s.%s", driver_name, attr_name)
+                            self.logger.debug(
+                                "Skipping non-writable attribute %s.%s",
+                                driver_name,
+                                attr_name,
+                            )
                             continue
 
                     try:
@@ -1218,19 +1565,40 @@ class TargetWriter:
                         if self.sysfs.valid_path(attr_path):
                             current_value = self.sysfs.read_sysfs_attribute(attr_path)
                             if current_value != attr_value:
-                                self.sysfs.write_sysfs(attr_path, attr_value, check_result=False)
-                                self.logger.debug("Set driver attribute %s.%s = %s", driver_name, attr_name, attr_value)
+                                self.sysfs.write_sysfs(
+                                    attr_path, attr_value, check_result=False
+                                )
+                                self.logger.debug(
+                                    "Set driver attribute %s.%s = %s",
+                                    driver_name,
+                                    attr_name,
+                                    attr_value,
+                                )
                         else:
                             # Fallback: attempt write even if path validation failed
-                            self.sysfs.write_sysfs(attr_path, attr_value, check_result=False)
-                            self.logger.debug("Set driver attribute %s.%s = %s", driver_name, attr_name, attr_value)
+                            self.sysfs.write_sysfs(
+                                attr_path, attr_value, check_result=False
+                            )
+                            self.logger.debug(
+                                "Set driver attribute %s.%s = %s",
+                                driver_name,
+                                attr_name,
+                                attr_value,
+                            )
                     except SCSTError as e:
-                        self.logger.warning("Failed to set driver attribute %s.%s: %s", driver_name, attr_name, e)
+                        self.logger.warning(
+                            "Failed to set driver attribute %s.%s: %s",
+                            driver_name,
+                            attr_name,
+                            e,
+                        )
 
     def _disable_target_if_possible(self, driver_name: str, target_name: str) -> None:
         """Disable target to prevent new connections if it has an enabled attribute"""
         try:
-            enabled_path = f"{self.sysfs.SCST_TARGETS}/{driver_name}/{target_name}/enabled"
+            enabled_path = (
+                f"{self.sysfs.SCST_TARGETS}/{driver_name}/{target_name}/enabled"
+            )
             if self.sysfs.valid_path(enabled_path):
                 self.sysfs.write_sysfs(enabled_path, "0", check_result=False)
                 self.logger.debug("Disabled target %s/%s", driver_name, target_name)
@@ -1238,10 +1606,14 @@ class TargetWriter:
             # Some targets may not have an 'enabled' attribute - this is okay
             pass
 
-    def _force_close_target_sessions(self, driver_name: str, target_name: str, timeout: int = 300) -> bool:
+    def _force_close_target_sessions(
+        self, driver_name: str, target_name: str, timeout: int = 300
+    ) -> bool:
         """Force close active sessions and wait for them to terminate"""
 
-        sessions_path = f"{self.sysfs.SCST_TARGETS}/{driver_name}/{target_name}/sessions"
+        sessions_path = (
+            f"{self.sysfs.SCST_TARGETS}/{driver_name}/{target_name}/sessions"
+        )
         if not self.sysfs.valid_path(sessions_path):
             return True  # No sessions directory means no sessions
 
@@ -1255,7 +1627,12 @@ class TargetWriter:
         if not sessions:
             return True  # No active sessions
 
-        self.logger.debug("Found %s active sessions for target %s/%s", len(sessions), driver_name, target_name)
+        self.logger.debug(
+            "Found %s active sessions for target %s/%s",
+            len(sessions),
+            driver_name,
+            target_name,
+        )
 
         # Try to force close sessions that support it
         force_closable_sessions = set()
@@ -1269,7 +1646,9 @@ class TargetWriter:
                     force_closable_sessions.add(session)
                     self.logger.debug("Initiated force close for session %s", session)
                 except SCSTError as e:
-                    self.logger.warning("Failed to force close session %s: %s", session, e)
+                    self.logger.warning(
+                        "Failed to force close session %s: %s", session, e
+                    )
 
         if not force_closable_sessions:
             self.logger.debug("No sessions support force close")
@@ -1283,7 +1662,9 @@ class TargetWriter:
             # Check which sessions have actually closed
             try:
                 current_sessions = set(self.sysfs.list_directory(sessions_path))
-                current_sessions = {s for s in current_sessions if s != self.sysfs.MGMT_INTERFACE}
+                current_sessions = {
+                    s for s in current_sessions if s != self.sysfs.MGMT_INTERFACE
+                }
 
                 # Remove sessions that are no longer active
                 closed_sessions = remaining_sessions - current_sessions
@@ -1299,10 +1680,16 @@ class TargetWriter:
                 break
 
         if remaining_sessions:
-            self.logger.warning("Sessions %s did not close within %s seconds", remaining_sessions, timeout)
+            self.logger.warning(
+                "Sessions %s did not close within %s seconds",
+                remaining_sessions,
+                timeout,
+            )
             return False
 
-        self.logger.debug("All sessions closed for target %s/%s", driver_name, target_name)
+        self.logger.debug(
+            "All sessions closed for target %s/%s", driver_name, target_name
+        )
         return True
 
     def remove_target(self, driver_name: str, target_name: str) -> None:
@@ -1315,7 +1702,11 @@ class TargetWriter:
 
             # Force close any active sessions
             if not self._force_close_target_sessions(driver_name, target_name):
-                self.logger.warning("Some sessions remained active for target %s/%s", driver_name, target_name)
+                self.logger.warning(
+                    "Some sessions remained active for target %s/%s",
+                    driver_name,
+                    target_name,
+                )
 
             # Clear all LUNs first
             luns_mgmt = f"{target_path}/luns/mgmt"
@@ -1340,10 +1731,17 @@ class TargetWriter:
             self.sysfs.write_sysfs(driver_mgmt, f"del_target {target_name}")
 
         except SCSTError as e:
-            self.logger.warning("Failed to remove target %s/%s: %s", driver_name, target_name, e)
+            self.logger.warning(
+                "Failed to remove target %s/%s: %s", driver_name, target_name, e
+            )
 
-    def _remove_obsolete_luns(self, driver_name: str, target_name: str,
-                              current_target: 'TargetConfig', new_target: 'TargetConfig') -> None:
+    def _remove_obsolete_luns(
+        self,
+        driver_name: str,
+        target_name: str,
+        current_target: "TargetConfig",
+        new_target: "TargetConfig",
+    ) -> None:
         """Remove LUNs that are not in the new configuration"""
         try:
             current_luns = set(current_target.luns.keys())
@@ -1351,15 +1749,22 @@ class TargetWriter:
             luns_to_remove = current_luns - new_luns
 
             if luns_to_remove:
-                luns_mgmt = f"{self.sysfs.SCST_TARGETS}/{driver_name}/{target_name}/luns/mgmt"
+                luns_mgmt = (
+                    f"{self.sysfs.SCST_TARGETS}/{driver_name}/{target_name}/luns/mgmt"
+                )
                 for lun_number in luns_to_remove:
                     self.sysfs.write_sysfs(luns_mgmt, f"del {lun_number}")
 
         except SCSTError as e:
             self.logger.warning("Failed to remove obsolete LUNs: %s", e)
 
-    def _remove_obsolete_groups(self, driver_name: str, target_name: str,
-                                current_target: 'TargetConfig', new_target: 'TargetConfig') -> None:
+    def _remove_obsolete_groups(
+        self,
+        driver_name: str,
+        target_name: str,
+        current_target: "TargetConfig",
+        new_target: "TargetConfig",
+    ) -> None:
         """Remove initiator groups that are not in the new configuration"""
         try:
             current_groups = set(current_target.groups.keys())
@@ -1370,8 +1775,10 @@ class TargetWriter:
                 groups_mgmt = f"{self.sysfs.SCST_TARGETS}/{driver_name}/{target_name}/ini_groups/mgmt"
                 for group_name in groups_to_remove:
                     # Clear group LUNs first
-                    group_luns_mgmt = (f"{self.sysfs.SCST_TARGETS}/{driver_name}/{target_name}"
-                                       f"/ini_groups/{group_name}/luns/mgmt")
+                    group_luns_mgmt = (
+                        f"{self.sysfs.SCST_TARGETS}/{driver_name}/{target_name}"
+                        f"/ini_groups/{group_name}/luns/mgmt"
+                    )
                     if self.sysfs.valid_path(group_luns_mgmt):
                         self.sysfs.write_sysfs(group_luns_mgmt, "clear")
                     # Remove the group
@@ -1381,9 +1788,8 @@ class TargetWriter:
             self.logger.warning("Failed to remove obsolete groups: %s", e)
 
     def _remove_obsolete_driver_attributes(
-            self,
-            current_config: 'SCSTConfig',
-            new_config: 'SCSTConfig') -> None:
+        self, current_config: "SCSTConfig", new_config: "SCSTConfig"
+    ) -> None:
         """Remove driver attributes that are no longer present in the new configuration"""
         for driver_name, current_driver_config in current_config.drivers.items():
             # Skip if driver not in new config (will be handled by driver removal)
@@ -1399,7 +1805,9 @@ class TargetWriter:
                 if attr_name not in new_attributes:
                     self._remove_driver_attribute(driver_name, attr_name)
 
-    def _update_driver_mgmt_attribute(self, driver_name: str, attr_name: str, desired_value: str) -> None:
+    def _update_driver_mgmt_attribute(
+        self, driver_name: str, attr_name: str, desired_value: str
+    ) -> None:
         """Incrementally update a driver management attribute by comparing current vs desired values.
 
         This implements the Perl scstadmin logic for driver dynamic attributes:
@@ -1420,7 +1828,7 @@ class TargetWriter:
         # Parse desired values from config
         desired_values = set()
         if desired_value:
-            for value in desired_value.split(';'):
+            for value in desired_value.split(";"):
                 value = value.strip()
                 if value:
                     desired_values.add(value)
@@ -1445,54 +1853,92 @@ class TargetWriter:
             try:
                 command = f"del_attribute {attr_name} {value}"
                 self.sysfs.write_sysfs(driver_mgmt, command, check_result=False)
-                self.logger.debug("Removed driver mgmt attribute %s.%s = %s", driver_name, attr_name, value)
+                self.logger.debug(
+                    "Removed driver mgmt attribute %s.%s = %s",
+                    driver_name,
+                    attr_name,
+                    value,
+                )
             except SCSTError as e:
-                self.logger.warning("Failed to remove driver mgmt attribute %s.%s=%s: %s",
-                                    driver_name, attr_name, value, e)
+                self.logger.warning(
+                    "Failed to remove driver mgmt attribute %s.%s=%s: %s",
+                    driver_name,
+                    attr_name,
+                    value,
+                    e,
+                )
 
         # Add new values
         for value in values_to_add:
             try:
                 command = f"add_attribute {attr_name} {value}"
                 self.sysfs.write_sysfs(driver_mgmt, command, check_result=False)
-                self.logger.debug("Added driver mgmt attribute %s.%s = %s", driver_name, attr_name, value)
+                self.logger.debug(
+                    "Added driver mgmt attribute %s.%s = %s",
+                    driver_name,
+                    attr_name,
+                    value,
+                )
             except SCSTError as e:
-                self.logger.warning("Failed to add driver mgmt attribute %s.%s=%s: %s",
-                                    driver_name, attr_name, value, e)
+                self.logger.warning(
+                    "Failed to add driver mgmt attribute %s.%s=%s: %s",
+                    driver_name,
+                    attr_name,
+                    value,
+                    e,
+                )
 
     def _remove_driver_attribute(self, driver_name: str, attr_name: str) -> None:
         """Remove a specific driver attribute by resetting it to default value or using mgmt commands"""
         try:
             # Check if this is a mgmt-controlled driver attribute
             mgmt_info = self.config_reader._get_target_mgmt_info(driver_name)
-            driver_mgmt_attrs = mgmt_info.get('driver_attributes', set())
+            driver_mgmt_attrs = mgmt_info.get("driver_attributes", set())
 
             if attr_name in driver_mgmt_attrs:
                 # Use incremental update with empty desired value to remove all
-                self._update_driver_mgmt_attribute(driver_name, attr_name, '')
+                self._update_driver_mgmt_attribute(driver_name, attr_name, "")
                 return
 
             # For regular sysfs attributes, reset to default value
             attr_path = f"{self.sysfs.SCST_TARGETS}/{driver_name}/{attr_name}"
 
             # Skip if attribute file doesn't exist or isn't writable
-            if not self.sysfs.valid_path(attr_path) or not os.access(attr_path, os.W_OK):
-                self.logger.debug("Cannot remove driver attribute %s.%s: not accessible", driver_name, attr_name)
+            if not self.sysfs.valid_path(attr_path) or not os.access(
+                attr_path, os.W_OK
+            ):
+                self.logger.debug(
+                    "Cannot remove driver attribute %s.%s: not accessible",
+                    driver_name,
+                    attr_name,
+                )
                 return
 
             # Get the default value for this attribute if possible
-            default_value = self.config_reader._get_driver_attribute_default(driver_name, attr_name)
+            default_value = self.config_reader._get_driver_attribute_default(
+                driver_name, attr_name
+            )
 
             if default_value is not None:
                 current_value = self.sysfs.read_sysfs_attribute(attr_path)
                 if current_value != default_value:
                     self.sysfs.write_sysfs(attr_path, default_value, check_result=False)
-                    self.logger.info("Reset driver attribute %s.%s to default: %s",
-                                     driver_name, attr_name, default_value)
+                    self.logger.info(
+                        "Reset driver attribute %s.%s to default: %s",
+                        driver_name,
+                        attr_name,
+                        default_value,
+                    )
             else:
                 # Try to reset to system default by writing newline
-                self.sysfs.write_sysfs(attr_path, '\n', check_result=False)
-                self.logger.debug("Reset driver attribute %s.%s to system default", driver_name, attr_name)
+                self.sysfs.write_sysfs(attr_path, "\n", check_result=False)
+                self.logger.debug(
+                    "Reset driver attribute %s.%s to system default",
+                    driver_name,
+                    attr_name,
+                )
 
         except SCSTError as e:
-            self.logger.warning("Failed to remove driver attribute %s.%s: %s", driver_name, attr_name, e)
+            self.logger.warning(
+                "Failed to remove driver attribute %s.%s: %s", driver_name, attr_name, e
+            )

--- a/scstadmin/writers/target_writer.py
+++ b/scstadmin/writers/target_writer.py
@@ -893,7 +893,7 @@ class TargetWriter:
                 return  # Driver not loaded or doesn't exist
 
             existing_targets = self.sysfs.list_directory(driver_path)
-            driver_attrs = self.DRIVER_ATTRIBUTES.get(driver_name, set())
+            driver_attrs = SCSTConstants.DRIVER_ATTRIBUTES.get(driver_name, set())
 
             for target in existing_targets:
                 # Filter out driver-level attributes and management interfaces

--- a/scstadmin/writers/utils.py
+++ b/scstadmin/writers/utils.py
@@ -1,13 +1,14 @@
 """
 Utility functions for SCST writers
 """
+
 import os
 import logging
 from typing import Dict, Set, Optional
 
 from ..constants import SCSTConstants
 
-logger = logging.getLogger('scstadmin.writers.utils')
+logger = logging.getLogger("scstadmin.writers.utils")
 
 
 def entity_exists(entity_path: str) -> bool:
@@ -18,11 +19,13 @@ def entity_exists(entity_path: str) -> bool:
         return False
 
 
-def attrs_config_differs(desired_attrs: Dict[str, str],
-                         current_attrs: Dict[str, str],
-                         skip_attrs: Optional[Set[str]] = None,
-                         removable_attrs: Optional[Set[str]] = None,
-                         entity_type: str = "attribute") -> bool:
+def attrs_config_differs(
+    desired_attrs: Dict[str, str],
+    current_attrs: Dict[str, str],
+    skip_attrs: Optional[Set[str]] = None,
+    removable_attrs: Optional[Set[str]] = None,
+    entity_type: str = "attribute",
+) -> bool:
     """Compare desired configuration attributes with current live values.
 
     This method performs intelligent configuration comparison to determine if
@@ -68,7 +71,8 @@ def attrs_config_differs(desired_attrs: Dict[str, str],
 
         if current_value != desired_value:
             logger.debug(
-                f"{entity_type} attribute '{attr}' differs: current='{current_value}', desired='{desired_value}'")
+                f"{entity_type} attribute '{attr}' differs: current='{current_value}', desired='{desired_value}'"
+            )
             return True
 
     # Check for removable attributes that exist in current but not in desired

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,13 +21,13 @@ def project_root():
 @pytest.fixture(scope="session")
 def fixtures_dir():
     """Path to the test fixtures directory."""
-    return Path(__file__).parent / 'fixtures'
+    return Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture
 def sample_basic_config():
     """Return a basic SCST configuration as text."""
-    return '''
+    return """
     HANDLER vdisk_fileio {
         DEVICE test_disk {
             filename /tmp/test.img
@@ -44,13 +44,13 @@ def sample_basic_config():
     }
 
     setup_id 12345
-    '''
+    """
 
 
 @pytest.fixture
 def sample_complex_config():
     """Return a more complex SCST configuration for testing."""
-    return '''
+    return """
     HANDLER vdisk_fileio {
         DEVICE disk1 {
             filename /path/to/disk1.img
@@ -103,4 +103,4 @@ def sample_complex_config():
 
     setup_id 67890
     max_tasklet_cmd 32
-    '''
+    """

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -38,23 +38,26 @@ DEVICE_GROUP controller_A {
     print("  Input config includes TARGET blocks with attributes")
 
     # Verify device group was parsed
-    assert 'controller_A' in config.device_groups
-    dg = config.device_groups['controller_A']
+    assert "controller_A" in config.device_groups
+    dg = config.device_groups["controller_A"]
 
     # Verify target group was parsed
-    assert 'disk_volumes' in dg.target_groups
-    tg = dg.target_groups['disk_volumes']
+    assert "disk_volumes" in dg.target_groups
+    tg = dg.target_groups["disk_volumes"]
 
     # Verify targets were parsed
-    expected_targets = ['iqn.2023-01.example.com:test1', 'iqn.2023-01.example.com:test2']
+    expected_targets = [
+        "iqn.2023-01.example.com:test1",
+        "iqn.2023-01.example.com:test2",
+    ]
     assert set(tg.targets) == set(expected_targets)
 
     # Verify target attributes were parsed
-    assert 'iqn.2023-01.example.com:test2' in tg.target_attributes
-    assert tg.target_attributes['iqn.2023-01.example.com:test2']['rel_tgt_id'] == '1'
+    assert "iqn.2023-01.example.com:test2" in tg.target_attributes
+    assert tg.target_attributes["iqn.2023-01.example.com:test2"]["rel_tgt_id"] == "1"
 
     # Verify group attributes were parsed
-    assert tg.attributes['cpu_mask'] == 'fff'
+    assert tg.attributes["cpu_mask"] == "fff"
 
     print(f"  ✓ Targets: {tg.targets}")
     print(f"  ✓ Target attributes: {dict(tg.target_attributes)}")
@@ -72,39 +75,41 @@ def test_target_group_config_comparison():
     # Mock the group writer's target_group_config_matches method
     def mock_target_group_config_matches(device_group, tgroup_name, tgroup_config):
         # Mock behavior: return True for identical configs, False for different ones
-        if hasattr(tgroup_config, 'target_attributes'):
-            test2_attrs = tgroup_config.target_attributes.get('iqn.2023-01.example.com:test2', {})
-            return test2_attrs.get('rel_tgt_id') == '1'
+        if hasattr(tgroup_config, "target_attributes"):
+            test2_attrs = tgroup_config.target_attributes.get(
+                "iqn.2023-01.example.com:test2", {}
+            )
+            return test2_attrs.get("rel_tgt_id") == "1"
         return False
 
     scst.group_writer.target_group_config_matches = mock_target_group_config_matches
 
     # Test identical config (should match)
     new_config_dict = {
-        'targets': ['iqn.2023-01.example.com:test1', 'iqn.2023-01.example.com:test2'],
-        'target_attributes': {
-            'iqn.2023-01.example.com:test2': {'rel_tgt_id': '1'}
-        },
-        'attributes': {'cpu_mask': 'fff'}
+        "targets": ["iqn.2023-01.example.com:test1", "iqn.2023-01.example.com:test2"],
+        "target_attributes": {"iqn.2023-01.example.com:test2": {"rel_tgt_id": "1"}},
+        "attributes": {"cpu_mask": "fff"},
     }
-    new_config = TargetGroupConfig.from_config_dict('tg1', new_config_dict)
+    new_config = TargetGroupConfig.from_config_dict("tg1", new_config_dict)
 
-    matches = scst.group_writer.target_group_config_matches('dg1', 'tg1', new_config)
+    matches = scst.group_writer.target_group_config_matches("dg1", "tg1", new_config)
     print("Test 2 - Identical target group configs:")
     print(f"  Should match: True, Got: {matches}")
     print()
 
     # Test different target attributes (should not match)
     different_config_dict = {
-        'targets': ['iqn.2023-01.example.com:test1', 'iqn.2023-01.example.com:test2'],
-        'target_attributes': {
-            'iqn.2023-01.example.com:test2': {'rel_tgt_id': '2'}  # Different value
+        "targets": ["iqn.2023-01.example.com:test1", "iqn.2023-01.example.com:test2"],
+        "target_attributes": {
+            "iqn.2023-01.example.com:test2": {"rel_tgt_id": "2"}  # Different value
         },
-        'attributes': {'cpu_mask': 'fff'}
+        "attributes": {"cpu_mask": "fff"},
     }
-    different_config = TargetGroupConfig.from_config_dict('tg1', different_config_dict)
+    different_config = TargetGroupConfig.from_config_dict("tg1", different_config_dict)
 
-    matches = scst.group_writer.target_group_config_matches('dg1', 'tg1', different_config)
+    matches = scst.group_writer.target_group_config_matches(
+        "dg1", "tg1", different_config
+    )
     print("Test 3 - Different target attributes:")
     print(f"  Should match: False, Got: {matches}")
     print()
@@ -118,31 +123,40 @@ def test_target_attribute_setting():
     scst.logger = Mock()
 
     # Mock os.path.isdir to return True for directory targets (with attributes)
-    with patch('os.path.isdir') as mock_isdir:
+    with patch("os.path.isdir") as mock_isdir:
         mock_isdir.return_value = True
 
         # Create a mock target config with attributes
         target_config = Mock()
-        target_config.attributes = {'rel_tgt_id': '1', 'preferred': '1'}
+        target_config.attributes = {"rel_tgt_id": "1", "preferred": "1"}
 
         # Test setting target attributes using the group writer
         scst.group_writer._set_target_group_target_attributes(
-            'dg1', 'tg1', 'iqn.2023-01.example.com:test', target_config.attributes)
+            "dg1", "tg1", "iqn.2023-01.example.com:test", target_config.attributes
+        )
 
         print("Test 4 - Setting target attributes:")
         print(f"  Target config: {target_config.attributes}")
 
         # Check that sysfs.write_sysfs was called correctly
         expected_calls = [
-            ('/sys/kernel/scst_tgt/device_groups/dg1/target_groups/tg1/iqn.2023-01.example.com:test/rel_tgt_id', '1'),
-            ('/sys/kernel/scst_tgt/device_groups/dg1/target_groups/tg1/iqn.2023-01.example.com:test/preferred', '1')
+            (
+                "/sys/kernel/scst_tgt/device_groups/dg1/target_groups/tg1/iqn.2023-01.example.com:test/rel_tgt_id",
+                "1",
+            ),
+            (
+                "/sys/kernel/scst_tgt/device_groups/dg1/target_groups/tg1/iqn.2023-01.example.com:test/preferred",
+                "1",
+            ),
         ]
 
         actual_calls = [call[0] for call in scst.sysfs.write_sysfs.call_args_list]
         print(f"  Expected sysfs writes: {len(expected_calls)}")
         print(f"  Actual sysfs writes: {len(actual_calls)}")
         for i, call in enumerate(actual_calls):
-            print(f"    Call {i+1}: write_sysfs('{call[0]}', '{call[1]}', check_result=False)")
+            print(
+                f"    Call {i + 1}: write_sysfs('{call[0]}', '{call[1]}', check_result=False)"
+            )
         print()
 
 
@@ -162,7 +176,7 @@ DEVICE_GROUP controller_A {
 """
 
     # Create temporary config file
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.conf', delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as f:
         f.write(config_text)
         temp_file = f.name
 
@@ -174,8 +188,8 @@ DEVICE_GROUP controller_A {
         print("  ✓ Config file successfully parsed")
 
         # Verify the structure
-        dg = config.device_groups['controller_A']
-        tg = dg.target_groups['disk_volumes']
+        dg = config.device_groups["controller_A"]
+        tg = dg.target_groups["disk_volumes"]
 
         print("  ✓ Device group 'controller_A' found")
         print("  ✓ Target group 'disk_volumes' found")
@@ -207,11 +221,12 @@ def main():
     except Exception as e:
         print(f"Test failed with error: {e}")
         import traceback
+
         traceback.print_exc()
         return 1
 
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,8 +11,10 @@ import sys
 # Imports handled by conftest.py
 
 from scstadmin.config import (
-    DeviceConfig, VdiskFileioDeviceConfig,
-    VdiskBlockioDeviceConfig, DevDiskDeviceConfig
+    DeviceConfig,
+    VdiskFileioDeviceConfig,
+    VdiskBlockioDeviceConfig,
+    DevDiskDeviceConfig,
 )
 
 
@@ -21,10 +23,7 @@ def test_vdisk_fileio():
     print("Testing VdiskFileioDeviceConfig...")
 
     device = VdiskFileioDeviceConfig(
-        name="disk1",
-        filename="/path/to/disk1.img",
-        blocksize="4096",
-        readonly="0"
+        name="disk1", filename="/path/to/disk1.img", blocksize="4096", readonly="0"
     )
 
     assert device.name == "disk1"
@@ -42,10 +41,7 @@ def test_vdisk_blockio():
     print("Testing VdiskBlockioDeviceConfig...")
 
     device = VdiskBlockioDeviceConfig(
-        name="block_disk",
-        filename="/dev/sdb",
-        nv_cache="1",
-        o_direct="1"
+        name="block_disk", filename="/dev/sdb", nv_cache="1", o_direct="1"
     )
 
     assert device.name == "block_disk"
@@ -61,11 +57,7 @@ def test_dev_disk():
     """Test DevDiskDeviceConfig creation and properties."""
     print("Testing DevDiskDeviceConfig...")
 
-    device = DevDiskDeviceConfig(
-        name="real_disk",
-        filename="/dev/sda",
-        readonly="1"
-    )
+    device = DevDiskDeviceConfig(name="real_disk", filename="/dev/sda", readonly="1")
 
     assert device.name == "real_disk"
     assert device.handler_type == "dev_disk"
@@ -94,7 +86,7 @@ def test_polymorphism():
     devices = [
         VdiskFileioDeviceConfig(name="file_dev", filename="/tmp/file.img"),
         VdiskBlockioDeviceConfig(name="block_dev", filename="/dev/sdb"),
-        DevDiskDeviceConfig(name="real_dev", filename="/dev/sda")
+        DevDiskDeviceConfig(name="real_dev", filename="/dev/sda"),
     ]
 
     for device in devices:
@@ -119,9 +111,10 @@ def main():
     except Exception as e:
         print(f"\n❌ Test failed: {e}")
         import traceback
+
         traceback.print_exc()
         return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/tests/test_copy_manager.py
+++ b/tests/test_copy_manager.py
@@ -20,10 +20,10 @@ def test_passthrough_detection():
 
         # Test with some common device names
         test_devices = [
-            'sda',      # Common disk device (likely passthrough)
-            'sdb',      # Common disk device (likely passthrough)
-            'vdisk1',   # Virtual disk (not passthrough)
-            'nullio1',  # Virtual device (not passthrough)
+            "sda",  # Common disk device (likely passthrough)
+            "sdb",  # Common disk device (likely passthrough)
+            "vdisk1",  # Virtual disk (not passthrough)
+            "nullio1",  # Virtual device (not passthrough)
         ]
 
         for device in test_devices:
@@ -42,41 +42,45 @@ def test_config_filtering():
     # Create a mock configuration with copy_manager LUNs
     config = SCSTConfig()
     config.drivers = {
-        'copy_manager': {
-            'targets': {
-                'copy_manager_tgt': {
-                    'luns': {
-                        '0': {'device': 'sda', 'attributes': {}},      # Passthrough device
-                        '1': {'device': 'vdisk1', 'attributes': {}},  # Virtual device
-                        '2': {'device': 'sdb', 'attributes': {}}      # Passthrough device
+        "copy_manager": {
+            "targets": {
+                "copy_manager_tgt": {
+                    "luns": {
+                        "0": {"device": "sda", "attributes": {}},  # Passthrough device
+                        "1": {"device": "vdisk1", "attributes": {}},  # Virtual device
+                        "2": {"device": "sdb", "attributes": {}},  # Passthrough device
                     },
-                    'groups': {
-                        'default': {
-                            'luns': {
-                                '10': {'device': 'sdc', 'attributes': {}},    # Passthrough
-                                '11': {'device': 'nullio1', 'attributes': {}}  # Virtual
+                    "groups": {
+                        "default": {
+                            "luns": {
+                                "10": {
+                                    "device": "sdc",
+                                    "attributes": {},
+                                },  # Passthrough
+                                "11": {
+                                    "device": "nullio1",
+                                    "attributes": {},
+                                },  # Virtual
                             },
-                            'initiators': [],
-                            'attributes': {}
+                            "initiators": [],
+                            "attributes": {},
                         }
                     },
-                    'attributes': {}
+                    "attributes": {},
                 }
             },
-            'attributes': {}
+            "attributes": {},
         },
-        'iscsi': {
-            'targets': {
-                'iqn.test': {
-                    'luns': {
-                        '0': {'device': 'vdisk1', 'attributes': {}}
-                    },
-                    'groups': {},
-                    'attributes': {}
+        "iscsi": {
+            "targets": {
+                "iqn.test": {
+                    "luns": {"0": {"device": "vdisk1", "attributes": {}}},
+                    "groups": {},
+                    "attributes": {},
                 }
             },
-            'attributes': {}
-        }
+            "attributes": {},
+        },
     }
 
     # Test by creating admin and calling write method
@@ -86,14 +90,14 @@ def test_config_filtering():
         # Mock the passthrough detection for testing
         def mock_is_passthrough(device):
             # Mock: assume sd* devices are passthrough, others are virtual
-            return device.startswith('sd')
+            return device.startswith("sd")
 
         # Replace the method for testing
         original_method = admin._is_passthrough_device
         admin._is_passthrough_device = mock_is_passthrough
 
         # Test configuration writing
-        test_file = '/tmp/test_scst_config.conf'
+        test_file = "/tmp/test_scst_config.conf"
 
         # Mock read_current_config to return our test config
         admin.read_current_config = lambda: config
@@ -102,14 +106,17 @@ def test_config_filtering():
 
         # Read and display the generated config
         print("Generated configuration (filtered):")
-        with open(test_file, 'r') as f:
+        with open(test_file, "r") as f:
             content = f.read()
             print(content)
 
         # Check if passthrough devices were filtered out
-        lines = content.split('\n')
-        copy_manager_luns = [line for line in lines
-                             if 'LUN' in line and ('sda' in line or 'sdb' in line or 'sdc' in line)]
+        lines = content.split("\n")
+        copy_manager_luns = [
+            line
+            for line in lines
+            if "LUN" in line and ("sda" in line or "sdb" in line or "sdc" in line)
+        ]
 
         if copy_manager_luns:
             print("\n❌ ERROR: Found passthrough device LUNs that should be filtered:")
@@ -119,7 +126,11 @@ def test_config_filtering():
             print("\n✅ SUCCESS: Passthrough device LUNs properly filtered out")
 
         # Check if virtual devices were preserved
-        virtual_luns = [line for line in lines if 'LUN' in line and ('vdisk1' in line or 'nullio1' in line)]
+        virtual_luns = [
+            line
+            for line in lines
+            if "LUN" in line and ("vdisk1" in line or "nullio1" in line)
+        ]
         if virtual_luns:
             print("✅ SUCCESS: Virtual device LUNs preserved:")
             for line in virtual_luns:
@@ -132,10 +143,11 @@ def test_config_filtering():
     except Exception as e:
         print(f"❌ ERROR: Configuration filtering test failed: {e}")
         import traceback
+
         traceback.print_exc()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print("Copy Manager LUN Filtering Test")
     print("=" * 40)
 

--- a/tests/test_device_attributes.py
+++ b/tests/test_device_attributes.py
@@ -7,7 +7,11 @@ import sys
 
 # Imports handled by conftest.py
 
-from scstadmin.config import VdiskFileioDeviceConfig, VdiskBlockioDeviceConfig, DevDiskDeviceConfig
+from scstadmin.config import (
+    VdiskFileioDeviceConfig,
+    VdiskBlockioDeviceConfig,
+    DevDiskDeviceConfig,
+)
 
 
 def test_device_attribute_properties():
@@ -20,7 +24,7 @@ def test_device_attribute_properties():
         filename="/path/to/file.img",
         blocksize="4096",
         readonly="0",
-        attributes={"custom_attr": "value", "t10_dev_id": "abc123"}
+        attributes={"custom_attr": "value", "t10_dev_id": "abc123"},
     )
 
     creation_attrs = fileio_device.creation_attributes
@@ -30,17 +34,17 @@ def test_device_attribute_properties():
     print(f"VdiskFileio post-creation attributes: {post_attrs}")
 
     # Verify creation attributes include known creation-time params
-    assert 'filename' in creation_attrs
-    assert 'blocksize' in creation_attrs
-    assert creation_attrs['filename'] == "/path/to/file.img"
-    assert creation_attrs['blocksize'] == "4096"
-    assert creation_attrs['read_only'] == "0"  # Note: readonly -> read_only
-    assert creation_attrs['t10_dev_id'] == "abc123"  # From attributes dict
+    assert "filename" in creation_attrs
+    assert "blocksize" in creation_attrs
+    assert creation_attrs["filename"] == "/path/to/file.img"
+    assert creation_attrs["blocksize"] == "4096"
+    assert creation_attrs["read_only"] == "0"  # Note: readonly -> read_only
+    assert creation_attrs["t10_dev_id"] == "abc123"  # From attributes dict
 
     # Verify post-creation attributes only have non-creation params
-    assert 'custom_attr' in post_attrs
-    assert 'filename' not in post_attrs  # Should not be in post-creation
-    assert 't10_dev_id' not in post_attrs  # Should be moved to creation
+    assert "custom_attr" in post_attrs
+    assert "filename" not in post_attrs  # Should not be in post-creation
+    assert "t10_dev_id" not in post_attrs  # Should be moved to creation
 
     print("✓ VdiskFileioDeviceConfig attributes work correctly")
 
@@ -49,7 +53,7 @@ def test_device_attribute_properties():
         name="test_blockio",
         filename="/dev/sdb",
         nv_cache="1",
-        attributes={"custom_attr": "value", "bind_alua_state": "1"}
+        attributes={"custom_attr": "value", "bind_alua_state": "1"},
     )
 
     creation_attrs = blockio_device.creation_attributes
@@ -58,11 +62,11 @@ def test_device_attribute_properties():
     print(f"VdiskBlockio creation attributes: {creation_attrs}")
     print(f"VdiskBlockio post-creation attributes: {post_attrs}")
 
-    assert 'filename' in creation_attrs
-    assert 'nv_cache' in creation_attrs
-    assert creation_attrs['bind_alua_state'] == "1"  # From attributes dict
-    assert 'custom_attr' in post_attrs
-    assert 'bind_alua_state' not in post_attrs  # Should be moved to creation
+    assert "filename" in creation_attrs
+    assert "nv_cache" in creation_attrs
+    assert creation_attrs["bind_alua_state"] == "1"  # From attributes dict
+    assert "custom_attr" in post_attrs
+    assert "bind_alua_state" not in post_attrs  # Should be moved to creation
 
     print("✓ VdiskBlockioDeviceConfig attributes work correctly")
 
@@ -71,7 +75,7 @@ def test_device_attribute_properties():
         name="test_dev_disk",
         filename="/dev/sda",
         readonly="1",
-        attributes={"custom_attr": "value"}
+        attributes={"custom_attr": "value"},
     )
 
     creation_attrs = dev_disk.creation_attributes
@@ -83,9 +87,9 @@ def test_device_attribute_properties():
     # DevDisk has NO creation-time parameters
     assert creation_attrs == {}
     # All attributes should be post-creation
-    assert 'read_only' in post_attrs  # Note: readonly -> read_only
-    assert 'custom_attr' in post_attrs
-    assert post_attrs['read_only'] == "1"
+    assert "read_only" in post_attrs  # Note: readonly -> read_only
+    assert "custom_attr" in post_attrs
+    assert post_attrs["read_only"] == "1"
 
     print("✓ DevDiskDeviceConfig attributes work correctly")
 
@@ -98,9 +102,10 @@ def main():
     except Exception as e:
         print(f"\n❌ Test failed: {e}")
         import traceback
+
         traceback.print_exc()
         return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -9,12 +9,12 @@ import logging
 from scstadmin.parser import SCSTConfigParser
 
 
-def setup_test_logging(level='INFO'):
+def setup_test_logging(level="INFO"):
     """Setup logging for testing"""
     logging.basicConfig(
         level=getattr(logging, level),
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%H:%M:%S'
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%H:%M:%S",
     )
 
 
@@ -25,7 +25,7 @@ def test_logging_levels():
 
     # Test parsing with INFO level
     print("1. Testing Configuration Parsing (INFO level):")
-    setup_test_logging('INFO')
+    setup_test_logging("INFO")
     parser = SCSTConfigParser()
 
     sample_config = """
@@ -46,7 +46,7 @@ TARGET_DRIVER iscsi {
 
     print()
     print("2. Testing Default WARNING level (should show less output):")
-    setup_test_logging('WARNING')
+    setup_test_logging("WARNING")
 
     try:
         parser.parse_config_text(sample_config)
@@ -56,7 +56,7 @@ TARGET_DRIVER iscsi {
 
     print()
     print("3. Testing DEBUG level (should show detailed output):")
-    setup_test_logging('DEBUG')
+    setup_test_logging("DEBUG")
 
     try:
         parser.parse_config_text(sample_config)
@@ -65,7 +65,7 @@ TARGET_DRIVER iscsi {
         print(f"   ❌ Parsing failed: {e}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_logging_levels()
     print()
     print("=== Logging Test Summary ===")

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -40,7 +40,7 @@ class TestSCSTModuleManager:
     def test_module_manager_initialization(self):
         """Test SCSTModuleManager can be initialized with proper logging setup."""
         manager = SCSTModuleManager()
-        assert hasattr(manager, 'logger')
+        assert hasattr(manager, "logger")
 
     def test_determine_required_modules_basic(self):
         """Test basic module determination with common handlers and drivers.
@@ -52,23 +52,23 @@ class TestSCSTModuleManager:
 
         # Create config with typical production handlers and drivers
         config = SCSTConfig()
-        config.handlers = {'vdisk_fileio': {}, 'dev_disk': {}}
-        config.drivers = {'iscsi': {}, 'qla2x00t': {}}
+        config.handlers = {"vdisk_fileio": {}, "dev_disk": {}}
+        config.drivers = {"iscsi": {}, "qla2x00t": {}}
 
         modules = manager.determine_required_modules(config)
 
         # Should include base scst module plus mapped modules from constants
         expected = {
-            'scst',         # Base SCST module - always required
-            'scst_vdisk',   # From vdisk_fileio handler mapping
-            'scst_disk',    # From dev_disk handler mapping
-            'iscsi_scst',   # From iscsi driver mapping
-            'qla2x00tgt',   # From qla2x00t driver mapping
-            'crc32c'        # From iscsi driver (base CRC module)
+            "scst",  # Base SCST module - always required
+            "scst_vdisk",  # From vdisk_fileio handler mapping
+            "scst_disk",  # From dev_disk handler mapping
+            "iscsi_scst",  # From iscsi driver mapping
+            "qla2x00tgt",  # From qla2x00t driver mapping
+            "crc32c",  # From iscsi driver (base CRC module)
         }
         assert expected.issubset(modules)
 
-    @patch('platform.machine')
+    @patch("platform.machine")
     def test_determine_required_modules_x86_iscsi(self, mock_machine):
         """Test iSCSI module determination on x86 platforms.
 
@@ -76,38 +76,38 @@ class TestSCSTModuleManager:
         for better iSCSI performance. Note: iSER modules are deliberately omitted
         and handled elsewhere in the codebase.
         """
-        mock_machine.return_value = 'x86_64'
+        mock_machine.return_value = "x86_64"
         manager = SCSTModuleManager()
 
         config = SCSTConfig()
-        config.drivers = {'iscsi': {}}
+        config.drivers = {"iscsi": {}}
 
         modules = manager.determine_required_modules(config)
 
         # Should include x86-specific CRC hardware acceleration
-        assert 'crc32c-intel' in modules  # Hardware-accelerated CRC on Intel
-        assert 'crc32c' in modules        # Base CRC module
-        assert 'iscsi_scst' in modules    # Core iSCSI target driver
+        assert "crc32c-intel" in modules  # Hardware-accelerated CRC on Intel
+        assert "crc32c" in modules  # Base CRC module
+        assert "iscsi_scst" in modules  # Core iSCSI target driver
 
-    @patch('platform.machine')
+    @patch("platform.machine")
     def test_determine_required_modules_non_x86_iscsi(self, mock_machine):
         """Test iSCSI module determination on non-x86 platforms.
 
         Non-x86 platforms (ARM, RISC-V, etc.) don't get the Intel-specific
         CRC acceleration modules but still get the base iSCSI functionality.
         """
-        mock_machine.return_value = 'aarch64'
+        mock_machine.return_value = "aarch64"
         manager = SCSTModuleManager()
 
         config = SCSTConfig()
-        config.drivers = {'iscsi': {}}
+        config.drivers = {"iscsi": {}}
 
         modules = manager.determine_required_modules(config)
 
         # Should not include x86-specific modules on ARM
-        assert 'crc32c-intel' not in modules
-        assert 'crc32c' in modules      # Base CRC module still needed
-        assert 'iscsi_scst' in modules  # Core iSCSI functionality
+        assert "crc32c-intel" not in modules
+        assert "crc32c" in modules  # Base CRC module still needed
+        assert "iscsi_scst" in modules  # Core iSCSI functionality
 
     def test_determine_required_modules_copy_manager(self):
         """Test module determination with copy_manager driver.
@@ -118,25 +118,25 @@ class TestSCSTModuleManager:
         manager = SCSTModuleManager()
 
         config = SCSTConfig()
-        config.drivers = {'copy_manager': {}}
+        config.drivers = {"copy_manager": {}}
 
         modules = manager.determine_required_modules(config)
 
         # copy_manager maps to None in constants (built into scst core)
-        assert modules == {'scst'}
+        assert modules == {"scst"}
 
-    @patch('os.path.exists')
+    @patch("os.path.exists")
     def test_is_module_loaded_basic(self, mock_exists):
         """Test basic module loading status check via /sys/module/."""
         mock_exists.return_value = True
         manager = SCSTModuleManager()
 
-        result = manager.is_module_loaded('scst_vdisk')
+        result = manager.is_module_loaded("scst_vdisk")
 
         assert result is True
-        mock_exists.assert_called_with('/sys/module/scst_vdisk')
+        mock_exists.assert_called_with("/sys/module/scst_vdisk")
 
-    @patch('os.path.exists')
+    @patch("os.path.exists")
     def test_is_module_loaded_hyphen_conversion(self, mock_exists):
         """Test module loading check with hyphen to underscore conversion.
 
@@ -146,13 +146,13 @@ class TestSCSTModuleManager:
         mock_exists.return_value = True
         manager = SCSTModuleManager()
 
-        result = manager.is_module_loaded('crc32c-intel')
+        result = manager.is_module_loaded("crc32c-intel")
 
         assert result is True
         # Should convert hyphen to underscore for sysfs path
-        mock_exists.assert_called_with('/sys/module/crc32c_intel')
+        mock_exists.assert_called_with("/sys/module/crc32c_intel")
 
-    @patch('os.path.exists')
+    @patch("os.path.exists")
     def test_is_module_loaded_crc32c_variants(self, mock_exists):
         """Test crc32c special case handling with multiple implementations.
 
@@ -163,64 +163,66 @@ class TestSCSTModuleManager:
 
         Any of these satisfies the crc32c requirement.
         """
+
         def exists_side_effect(path):
             # Simulate crc32c_intel being loaded but not others
-            return path == '/sys/module/crc32c_intel'
+            return path == "/sys/module/crc32c_intel"
 
         mock_exists.side_effect = exists_side_effect
         manager = SCSTModuleManager()
 
-        result = manager.is_module_loaded('crc32c')
+        result = manager.is_module_loaded("crc32c")
 
         assert result is True
         # Should check crc32c variants until it finds one (any() short-circuits)
         # In this case, crc32c_intel returns True so it stops there
         actual_calls = [str(call[0][0]) for call in mock_exists.call_args_list]
-        assert '/sys/module/crc32c_intel' in actual_calls
+        assert "/sys/module/crc32c_intel" in actual_calls
         # Should not check remaining variants after finding the first one
         assert len(actual_calls) == 1
 
-    @patch('os.path.exists')
+    @patch("os.path.exists")
     def test_is_module_loaded_crc32c_fallback_check(self, mock_exists):
         """Test crc32c checking fallback implementations when first isn't available."""
+
         def exists_side_effect(path):
             # Simulate only libcrc32c being loaded (third variant)
-            return path == '/sys/module/libcrc32c'
+            return path == "/sys/module/libcrc32c"
 
         mock_exists.side_effect = exists_side_effect
         manager = SCSTModuleManager()
 
-        result = manager.is_module_loaded('crc32c')
+        result = manager.is_module_loaded("crc32c")
 
         assert result is True
         # Should check all variants until it finds libcrc32c
         actual_calls = [str(call[0][0]) for call in mock_exists.call_args_list]
         expected_calls = [
-            '/sys/module/crc32c_intel',
-            '/sys/module/crc32c_generic',
-            '/sys/module/libcrc32c'
+            "/sys/module/crc32c_intel",
+            "/sys/module/crc32c_generic",
+            "/sys/module/libcrc32c",
         ]
         assert actual_calls == expected_calls
 
-    @patch('os.path.exists')
+    @patch("os.path.exists")
     def test_is_module_loaded_crc32c_not_loaded(self, mock_exists):
         """Test crc32c check when no implementation variants are loaded."""
         mock_exists.return_value = False
         manager = SCSTModuleManager()
 
-        result = manager.is_module_loaded('crc32c')
+        result = manager.is_module_loaded("crc32c")
 
         assert result is False
         # Should check all variants when none are found
         actual_calls = [str(call[0][0]) for call in mock_exists.call_args_list]
         expected_calls = [
-            '/sys/module/crc32c_intel',
-            '/sys/module/crc32c_generic',
-            '/sys/module/libcrc32c'
+            "/sys/module/crc32c_intel",
+            "/sys/module/crc32c_generic",
+            "/sys/module/libcrc32c",
         ]
         assert actual_calls == expected_calls
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_load_module_success(self, mock_run):
         """Test successful module loading using modprobe."""
         mock_result = Mock()
@@ -228,17 +230,14 @@ class TestSCSTModuleManager:
         mock_run.return_value = mock_result
 
         manager = SCSTModuleManager()
-        result = manager.load_module('scst_vdisk')
+        result = manager.load_module("scst_vdisk")
 
         assert result is True
         mock_run.assert_called_with(
-            ['modprobe', 'scst_vdisk'],
-            capture_output=True,
-            text=True,
-            timeout=30
+            ["modprobe", "scst_vdisk"], capture_output=True, text=True, timeout=30
         )
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_load_module_failure_required(self, mock_run):
         """Test failed loading of a required module (should return False).
 
@@ -247,15 +246,15 @@ class TestSCSTModuleManager:
         """
         mock_result = Mock()
         mock_result.returncode = 1
-        mock_result.stderr = 'Module not found'
+        mock_result.stderr = "Module not found"
         mock_run.return_value = mock_result
 
         manager = SCSTModuleManager()
-        result = manager.load_module('scst_vdisk')
+        result = manager.load_module("scst_vdisk")
 
         assert result is False
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_load_module_failure_optional(self, mock_run):
         """Test failed loading of optional module (should continue gracefully).
 
@@ -264,45 +263,47 @@ class TestSCSTModuleManager:
         """
         mock_result = Mock()
         mock_result.returncode = 1
-        mock_result.stderr = 'Module not found'
+        mock_result.stderr = "Module not found"
         mock_run.return_value = mock_result
 
         manager = SCSTModuleManager()
         # crc32c-intel is marked as optional in constants
-        result = manager.load_module('crc32c-intel')
+        result = manager.load_module("crc32c-intel")
 
         assert result is True  # Should continue without optional modules
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_load_module_timeout(self, mock_run):
         """Test module loading timeout handling."""
-        mock_run.side_effect = subprocess.TimeoutExpired('modprobe', 30)
+        mock_run.side_effect = subprocess.TimeoutExpired("modprobe", 30)
 
         manager = SCSTModuleManager()
-        result = manager.load_module('scst_vdisk')
+        result = manager.load_module("scst_vdisk")
 
         assert result is False
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_load_module_exception(self, mock_run):
         """Test module loading with unexpected exception."""
-        mock_run.side_effect = Exception('Unexpected error')
+        mock_run.side_effect = Exception("Unexpected error")
 
         manager = SCSTModuleManager()
-        result = manager.load_module('scst_vdisk')
+        result = manager.load_module("scst_vdisk")
 
         assert result is False
 
-    @patch.object(SCSTModuleManager, 'determine_required_modules')
-    @patch.object(SCSTModuleManager, 'is_module_loaded')
-    @patch.object(SCSTModuleManager, 'load_module')
-    def test_ensure_required_modules_loaded_success(self, mock_load, mock_is_loaded, mock_determine):
+    @patch.object(SCSTModuleManager, "determine_required_modules")
+    @patch.object(SCSTModuleManager, "is_module_loaded")
+    @patch.object(SCSTModuleManager, "load_module")
+    def test_ensure_required_modules_loaded_success(
+        self, mock_load, mock_is_loaded, mock_determine
+    ):
         """Test successful loading of all required modules.
 
         This tests the main orchestration method that analyzes the config,
         checks module status, and loads missing modules.
         """
-        mock_determine.return_value = {'scst', 'scst_vdisk', 'iscsi_scst'}
+        mock_determine.return_value = {"scst", "scst_vdisk", "iscsi_scst"}
         # scst not loaded, vdisk already loaded, iscsi not loaded
         mock_is_loaded.side_effect = [False, True, False]
         mock_load.return_value = True
@@ -316,16 +317,18 @@ class TestSCSTModuleManager:
         # Should attempt to load only the unloaded modules
         assert mock_load.call_count == 2  # scst and iscsi_scst
 
-    @patch.object(SCSTModuleManager, 'determine_required_modules')
-    @patch.object(SCSTModuleManager, 'is_module_loaded')
-    @patch.object(SCSTModuleManager, 'load_module')
-    def test_ensure_required_modules_loaded_failure(self, mock_load, mock_is_loaded, mock_determine):
+    @patch.object(SCSTModuleManager, "determine_required_modules")
+    @patch.object(SCSTModuleManager, "is_module_loaded")
+    @patch.object(SCSTModuleManager, "load_module")
+    def test_ensure_required_modules_loaded_failure(
+        self, mock_load, mock_is_loaded, mock_determine
+    ):
         """Test failure when required modules cannot be loaded.
 
         When core SCST modules fail to load, the operation should fail fast
         with a clear error message indicating which modules failed.
         """
-        mock_determine.return_value = {'scst', 'scst_vdisk'}
+        mock_determine.return_value = {"scst", "scst_vdisk"}
         mock_is_loaded.return_value = False
         mock_load.side_effect = [True, False]  # First succeeds, second fails
 
@@ -335,17 +338,19 @@ class TestSCSTModuleManager:
         with pytest.raises(SCSTError, match="Failed to load required modules"):
             manager.ensure_required_modules_loaded(config)
 
-    @patch.object(SCSTModuleManager, 'determine_required_modules')
-    @patch.object(SCSTModuleManager, 'is_module_loaded')
-    @patch.object(SCSTModuleManager, 'load_module')
-    def test_ensure_required_modules_loaded_optional_failure_ok(self, mock_load, mock_is_loaded, mock_determine):
+    @patch.object(SCSTModuleManager, "determine_required_modules")
+    @patch.object(SCSTModuleManager, "is_module_loaded")
+    @patch.object(SCSTModuleManager, "load_module")
+    def test_ensure_required_modules_loaded_optional_failure_ok(
+        self, mock_load, mock_is_loaded, mock_determine
+    ):
         """Test that optional module failures don't cause overall failure.
 
         Optional modules like hardware CRC acceleration should not prevent
         SCST from starting if they fail to load - the system should continue
         with software fallbacks.
         """
-        mock_determine.return_value = {'scst', 'crc32c', 'crc32c-intel'}
+        mock_determine.return_value = {"scst", "crc32c", "crc32c-intel"}
         mock_is_loaded.return_value = False
         mock_load.side_effect = [True, True, True]  # All succeed
 
@@ -364,11 +369,14 @@ class TestSCSTModuleManager:
         """
         manager = SCSTModuleManager()
         config = SCSTConfig()
-        config.handlers = {'vdisk_fileio': {}}
+        config.handlers = {"vdisk_fileio": {}}
 
-        with patch.object(manager, 'is_module_loaded', return_value=True) as mock_is_loaded, \
-             patch.object(manager, 'load_module') as mock_load:
-
+        with (
+            patch.object(
+                manager, "is_module_loaded", return_value=True
+            ) as mock_is_loaded,
+            patch.object(manager, "load_module") as mock_load,
+        ):
             manager.ensure_required_modules_loaded(config)
 
             # Should check if modules are loaded but skip loading them

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,7 +12,12 @@ from pathlib import Path
 # Imports handled by conftest.py
 from scstadmin.parser import SCSTConfigParser
 from scstadmin.exceptions import SCSTError
-from scstadmin.config import SCSTConfig, LunConfig, InitiatorGroupConfig, VdiskBlockioDeviceConfig
+from scstadmin.config import (
+    SCSTConfig,
+    LunConfig,
+    InitiatorGroupConfig,
+    VdiskBlockioDeviceConfig,
+)
 
 
 class TestSCSTConfigParser:
@@ -26,16 +31,16 @@ class TestSCSTConfigParser:
     @pytest.fixture
     def fixtures_dir(self):
         """Path to test fixtures directory."""
-        return Path(__file__).parent / 'fixtures'
+        return Path(__file__).parent / "fixtures"
 
     def test_parser_initialization(self, parser):
         """Test parser initializes correctly."""
         assert parser is not None
-        assert hasattr(parser, 'logger')
+        assert hasattr(parser, "logger")
 
     def test_parse_basic_config(self, parser, fixtures_dir):
         """Test parsing a basic valid configuration."""
-        config_path = fixtures_dir / 'valid_configs' / 'basic.conf'
+        config_path = fixtures_dir / "valid_configs" / "basic.conf"
         config = parser.parse_config_file(str(config_path))
 
         # Verify config structure
@@ -49,139 +54,141 @@ class TestSCSTConfigParser:
 
     def test_parse_handlers_section(self, parser, fixtures_dir):
         """Test parsing HANDLER blocks."""
-        config_path = fixtures_dir / 'valid_configs' / 'basic.conf'
+        config_path = fixtures_dir / "valid_configs" / "basic.conf"
         config = parser.parse_config_file(str(config_path))
 
         # Check handlers exist
-        assert 'vdisk_fileio' in config.handlers
-        assert 'dev_disk' in config.handlers
+        assert "vdisk_fileio" in config.handlers
+        assert "dev_disk" in config.handlers
 
         # Note: The current parser structure stores devices directly in the config.devices
         # rather than nested under handlers. Check the devices section instead.
-        assert 'disk1' in config.devices
-        assert 'disk2' in config.devices
-        assert 'sda' in config.devices
+        assert "disk1" in config.devices
+        assert "disk2" in config.devices
+        assert "sda" in config.devices
 
         # Check device attributes - now using structured objects
-        disk1 = config.devices['disk1']
-        assert disk1.filename == '/path/to/disk1.img'
-        assert disk1.blocksize == '4096'
-        assert disk1.readonly == '0'
-        assert disk1.handler_type == 'vdisk_fileio'
+        disk1 = config.devices["disk1"]
+        assert disk1.filename == "/path/to/disk1.img"
+        assert disk1.blocksize == "4096"
+        assert disk1.readonly == "0"
+        assert disk1.handler_type == "vdisk_fileio"
 
         # Check quoted paths
-        disk2 = config.devices['disk2']
-        assert disk2.filename == '/path with spaces/disk2.img'
+        disk2 = config.devices["disk2"]
+        assert disk2.filename == "/path with spaces/disk2.img"
 
     def test_parse_target_drivers(self, parser, fixtures_dir):
         """Test parsing TARGET_DRIVER blocks."""
-        config_path = fixtures_dir / 'valid_configs' / 'basic.conf'
+        config_path = fixtures_dir / "valid_configs" / "basic.conf"
         config = parser.parse_config_file(str(config_path))
 
         # Check drivers
-        assert 'iscsi' in config.drivers
-        assert 'copy_manager' in config.drivers
+        assert "iscsi" in config.drivers
+        assert "copy_manager" in config.drivers
 
-        iscsi_driver = config.drivers['iscsi']
-        assert iscsi_driver.attributes['enabled'] == '1'
+        iscsi_driver = config.drivers["iscsi"]
+        assert iscsi_driver.attributes["enabled"] == "1"
 
         # Check targets within drivers
         targets = iscsi_driver.targets
-        assert 'iqn.2024-01.com.example:target1' in targets
+        assert "iqn.2024-01.com.example:target1" in targets
         # Note: The quoted target name might have parsing issues - let's check what's actually there
         target_names = list(targets.keys())
         assert len(target_names) >= 2  # Should have at least 2 targets
 
     def test_parse_lun_assignments(self, parser, fixtures_dir):
         """Test parsing LUN assignments within targets."""
-        config_path = fixtures_dir / 'valid_configs' / 'basic.conf'
+        config_path = fixtures_dir / "valid_configs" / "basic.conf"
         config = parser.parse_config_file(str(config_path))
 
-        target = config.drivers['iscsi'].targets['iqn.2024-01.com.example:target1']
+        target = config.drivers["iscsi"].targets["iqn.2024-01.com.example:target1"]
 
         # Check LUN assignments
         luns = target.luns
 
-        assert '0' in luns
-        assert '1' in luns
+        assert "0" in luns
+        assert "1" in luns
 
         # Check LUN devices - now using LunConfig objects
-        lun_0 = luns['0']
-        lun_1 = luns['1']
-        assert lun_0.device == 'disk1'
-        assert lun_1.device == 'disk2'
+        lun_0 = luns["0"]
+        lun_1 = luns["1"]
+        assert lun_0.device == "disk1"
+        assert lun_1.device == "disk2"
 
         # Check LUN attributes are in the attributes dict
-        assert lun_1.attributes['read_only'] == '1'
+        assert lun_1.attributes["read_only"] == "1"
 
     def test_parse_device_groups(self, parser, fixtures_dir):
         """Test parsing DEVICE_GROUP blocks."""
-        config_path = fixtures_dir / 'valid_configs' / 'basic.conf'
+        config_path = fixtures_dir / "valid_configs" / "basic.conf"
         config = parser.parse_config_file(str(config_path))
 
         # Check device groups
-        assert 'group1' in config.device_groups
-        group1 = config.device_groups['group1']
+        assert "group1" in config.device_groups
+        group1 = config.device_groups["group1"]
 
         # Check devices in group (stored as a list)
-        assert 'disk1' in group1.devices
-        assert 'disk2' in group1.devices
+        assert "disk1" in group1.devices
+        assert "disk2" in group1.devices
 
         # Check target groups
-        assert 'tg1' in group1.target_groups
+        assert "tg1" in group1.target_groups
 
-        tg1 = group1.target_groups['tg1']
-        assert 'iqn.2024-01.com.example:target1' in tg1.targets
+        tg1 = group1.target_groups["tg1"]
+        assert "iqn.2024-01.com.example:target1" in tg1.targets
 
         # Note: LUNs in target groups may not be parsed the same way as target LUNs
         # Let's check if they exist, but don't require a specific structure for now
 
     def test_parse_global_attributes(self, parser, fixtures_dir):
         """Test parsing global SCST attributes."""
-        config_path = fixtures_dir / 'valid_configs' / 'basic.conf'
+        config_path = fixtures_dir / "valid_configs" / "basic.conf"
         config = parser.parse_config_file(str(config_path))
 
         # Check global attributes
-        assert config.scst_attributes['setup_id'] == '12345'
-        assert config.scst_attributes['max_tasklet_cmd'] == '16'
+        assert config.scst_attributes["setup_id"] == "12345"
+        assert config.scst_attributes["max_tasklet_cmd"] == "16"
 
     def test_parse_complex_config(self, parser, fixtures_dir):
         """Test parsing a complex configuration with edge cases."""
-        config_path = fixtures_dir / 'valid_configs' / 'complex.conf'
+        config_path = fixtures_dir / "valid_configs" / "complex.conf"
         config = parser.parse_config_file(str(config_path))
 
         # Check multiple handlers
-        assert 'vdisk_blockio' in config.handlers
+        assert "vdisk_blockio" in config.handlers
 
         # Check complex device attributes - now using structured DeviceConfig objects
-        complex_disk = config.devices['complex_disk']
+        complex_disk = config.devices["complex_disk"]
         assert isinstance(complex_disk, VdiskBlockioDeviceConfig)
-        assert complex_disk.nv_cache == '1'
-        assert complex_disk.o_direct == '1'
-        assert complex_disk.thin_provisioned == '0'
+        assert complex_disk.nv_cache == "1"
+        assert complex_disk.o_direct == "1"
+        assert complex_disk.thin_provisioned == "0"
 
         # Check simple device
-        simple_disk = config.devices['simple_disk']
+        simple_disk = config.devices["simple_disk"]
         assert isinstance(simple_disk, VdiskBlockioDeviceConfig)
-        assert simple_disk.filename == '/dev/mapper/simple-lv'
+        assert simple_disk.filename == "/dev/mapper/simple-lv"
 
         # Check multiple drivers
-        assert 'iscsi' in config.drivers
-        assert 'qla2x00t' in config.drivers
+        assert "iscsi" in config.drivers
+        assert "qla2x00t" in config.drivers
 
         # Check high LUN numbers
-        iscsi_target = config.drivers['iscsi'].targets['iqn.2024-01.com.example:complex']
-        assert '255' in iscsi_target.luns
-        lun_255 = iscsi_target.luns['255']
-        assert lun_255.attributes['read_only'] == '1'
+        iscsi_target = config.drivers["iscsi"].targets[
+            "iqn.2024-01.com.example:complex"
+        ]
+        assert "255" in iscsi_target.luns
+        lun_255 = iscsi_target.luns["255"]
+        assert lun_255.attributes["read_only"] == "1"
 
         # Check multiple device groups
-        assert 'production_group' in config.device_groups
-        assert 'test_group' in config.device_groups
+        assert "production_group" in config.device_groups
+        assert "test_group" in config.device_groups
 
     def test_quote_stripping(self, parser):
         """Test quote handling in attribute values."""
-        test_config = '''
+        test_config = """
         HANDLER vdisk_fileio {
             DEVICE test {
                 filename "/quoted/path"
@@ -190,21 +197,23 @@ class TestSCSTConfigParser:
                 mixed_quotes "/mixed'quotes/path"
             }
         }
-        '''
+        """
         config = parser.parse_config_text(test_config)
 
         # Devices are now structured DeviceConfig objects
-        device = config.devices['test']
-        assert device.filename == '/quoted/path'
+        device = config.devices["test"]
+        assert device.filename == "/quoted/path"
 
         # Other attributes go into the attributes dict for non-standard fields
-        assert device.attributes['unquoted_path'] == '/unquoted/path'
-        assert device.attributes['single_quotes'] == '/single/quoted/path'  # Single quotes not stripped
-        assert device.attributes['mixed_quotes'] == "/mixed'quotes/path"
+        assert device.attributes["unquoted_path"] == "/unquoted/path"
+        assert (
+            device.attributes["single_quotes"] == "/single/quoted/path"
+        )  # Single quotes not stripped
+        assert device.attributes["mixed_quotes"] == "/mixed'quotes/path"
 
     def test_comment_handling(self, parser):
         """Test that comments are properly ignored (simplified version without inline comments)."""
-        test_config = '''
+        test_config = """
         # This is a comment
         HANDLER vdisk_fileio {
             DEVICE test {
@@ -213,20 +222,20 @@ class TestSCSTConfigParser:
             }
         }
         # Final comment
-        '''
+        """
         config = parser.parse_config_text(test_config)
 
         # Comments should be ignored, basic structure should parse
-        assert 'vdisk_fileio' in config.handlers
-        assert 'test' in config.devices
+        assert "vdisk_fileio" in config.handlers
+        assert "test" in config.devices
 
-        device = config.devices['test']
-        assert device.filename == '/path/to/file'
-        assert device.blocksize == '4096'
+        device = config.devices["test"]
+        assert device.filename == "/path/to/file"
+        assert device.blocksize == "4096"
 
     def test_empty_blocks(self, parser):
         """Test handling of empty blocks."""
-        test_config = '''
+        test_config = """
         HANDLER vdisk_fileio {
             DEVICE empty_device {
             }
@@ -236,43 +245,45 @@ class TestSCSTConfigParser:
             TARGET empty_target {
             }
         }
-        '''
+        """
         config = parser.parse_config_text(test_config)
 
         # With structured objects, devices are at top level, not nested under handlers
-        assert 'empty_device' in config.devices
-        assert 'empty_target' in config.drivers['iscsi'].targets
+        assert "empty_device" in config.devices
+        assert "empty_target" in config.drivers["iscsi"].targets
 
         # Verify the empty device was created properly
-        empty_device = config.devices['empty_device']
-        assert empty_device.handler_type == 'vdisk_fileio'
-        assert empty_device.filename == ''  # Empty device should have empty filename
+        empty_device = config.devices["empty_device"]
+        assert empty_device.handler_type == "vdisk_fileio"
+        assert empty_device.filename == ""  # Empty device should have empty filename
 
     def test_missing_file_error(self, parser):
         """Test error handling for missing configuration files."""
         with pytest.raises(SCSTError) as exc_info:
-            parser.parse_config_file('/nonexistent/path/config.conf')
+            parser.parse_config_file("/nonexistent/path/config.conf")
 
-        assert 'No such file or directory' in str(exc_info.value) or 'cannot find the file' in str(exc_info.value)
+        assert "No such file or directory" in str(
+            exc_info.value
+        ) or "cannot find the file" in str(exc_info.value)
 
     def test_syntax_error_reporting(self, parser, fixtures_dir):
         """Test that syntax errors are reported with line numbers."""
-        config_path = fixtures_dir / 'invalid_configs' / 'missing_braces.conf'
+        config_path = fixtures_dir / "invalid_configs" / "missing_braces.conf"
 
         with pytest.raises(SCSTError) as exc_info:
             parser.parse_config_file(str(config_path))
 
         # Should include line number information
         error_msg = str(exc_info.value)
-        assert 'line' in error_msg.lower()
+        assert "line" in error_msg.lower()
 
     def test_invalid_block_type(self, parser):
         """Test handling of invalid block types (parser ignores unknown blocks)."""
-        test_config = '''
+        test_config = """
         INVALID_BLOCK_TYPE test {
             some_attr value
         }
-        '''
+        """
 
         # Parser should ignore unknown blocks and continue (lenient parsing)
         config = parser.parse_config_text(test_config)
@@ -284,28 +295,28 @@ class TestSCSTConfigParser:
 
     def test_malformed_lun_assignment(self, parser):
         """Test error handling for malformed LUN assignments."""
-        test_config = '''
+        test_config = """
         TARGET_DRIVER iscsi {
             TARGET iqn.test:target {
                 LUN invalid_number device_name
             }
         }
-        '''
+        """
 
         # This should either parse gracefully or raise a clear error
         # Depending on implementation, we might want to be more lenient
         try:
             config = parser.parse_config_text(test_config)
             # If it parses, verify the structure
-            target = config.drivers['iscsi'].targets['iqn.test:target']
-            assert hasattr(target, 'luns')
+            target = config.drivers["iscsi"].targets["iqn.test:target"]
+            assert hasattr(target, "luns")
         except SCSTError as e:
             # If it raises an error, it should be descriptive
-            assert 'LUN' in str(e)
+            assert "LUN" in str(e)
 
     def test_whitespace_handling(self, parser):
         """Test proper handling of various whitespace scenarios."""
-        test_config = '''
+        test_config = """
 
         HANDLER   vdisk_fileio   {
             DEVICE    test    {
@@ -321,23 +332,23 @@ class TestSCSTConfigParser:
             }
         }
 
-        '''
+        """
 
         config = parser.parse_config_text(test_config)
 
         # Should parse correctly despite extra whitespace
-        assert 'vdisk_fileio' in config.handlers
-        assert 'test' in config.devices
+        assert "vdisk_fileio" in config.handlers
+        assert "test" in config.devices
 
         # Verify device parsed correctly with whitespace handling
-        test_device = config.devices['test']
-        assert test_device.handler_type == 'vdisk_fileio'
-        assert test_device.filename == '/path/to/file'
-        assert test_device.blocksize == '4096'
+        test_device = config.devices["test"]
+        assert test_device.handler_type == "vdisk_fileio"
+        assert test_device.filename == "/path/to/file"
+        assert test_device.blocksize == "4096"
 
     def test_parse_target_group_attributes(self, parser):
         """Test parsing target group attributes and target-specific attributes."""
-        test_config = '''
+        test_config = """
         DEVICE_GROUP production {
             DEVICE disk1
             DEVICE disk2
@@ -362,43 +373,49 @@ class TestSCSTConfigParser:
                 }
             }
         }
-        '''
+        """
 
         config = parser.parse_config_text(test_config)
 
         # Check device group
-        assert 'production' in config.device_groups
-        group = config.device_groups['production']
-        assert 'disk1' in group.devices
-        assert 'disk2' in group.devices
+        assert "production" in config.device_groups
+        group = config.device_groups["production"]
+        assert "disk1" in group.devices
+        assert "disk2" in group.devices
 
         # Check controller_A target group
-        assert 'controller_A' in group.target_groups
-        tg_a = group.target_groups['controller_A']
-        assert tg_a.attributes['group_id'] == '101'
-        assert tg_a.attributes['state'] == 'active'
-        assert 'iqn.2005-10.org.freenas.ctl:test1' in tg_a.targets
-        assert 'iqn.2005-10.org.freenas.ctl:test2' in tg_a.targets
+        assert "controller_A" in group.target_groups
+        tg_a = group.target_groups["controller_A"]
+        assert tg_a.attributes["group_id"] == "101"
+        assert tg_a.attributes["state"] == "active"
+        assert "iqn.2005-10.org.freenas.ctl:test1" in tg_a.targets
+        assert "iqn.2005-10.org.freenas.ctl:test2" in tg_a.targets
 
         # Check target-specific attributes
-        assert 'iqn.2005-10.org.freenas.ctl:test1' in tg_a.target_attributes
-        assert tg_a.target_attributes['iqn.2005-10.org.freenas.ctl:test1']['rel_tgt_id'] == '1'
+        assert "iqn.2005-10.org.freenas.ctl:test1" in tg_a.target_attributes
+        assert (
+            tg_a.target_attributes["iqn.2005-10.org.freenas.ctl:test1"]["rel_tgt_id"]
+            == "1"
+        )
 
         # Check controller_B target group
-        assert 'controller_B' in group.target_groups
-        tg_b = group.target_groups['controller_B']
-        assert tg_b.attributes['group_id'] == '102'
-        assert tg_b.attributes['state'] == 'nonoptimized'
-        assert 'iqn.2005-10.org.freenas.ctl:HA:test1' in tg_b.targets
-        assert 'iqn.2005-10.org.freenas.ctl:HA:test2' in tg_b.targets
+        assert "controller_B" in group.target_groups
+        tg_b = group.target_groups["controller_B"]
+        assert tg_b.attributes["group_id"] == "102"
+        assert tg_b.attributes["state"] == "nonoptimized"
+        assert "iqn.2005-10.org.freenas.ctl:HA:test1" in tg_b.targets
+        assert "iqn.2005-10.org.freenas.ctl:HA:test2" in tg_b.targets
 
         # Check target-specific attributes
-        assert 'iqn.2005-10.org.freenas.ctl:HA:test2' in tg_b.target_attributes
-        assert tg_b.target_attributes['iqn.2005-10.org.freenas.ctl:HA:test2']['rel_tgt_id'] == '2'
+        assert "iqn.2005-10.org.freenas.ctl:HA:test2" in tg_b.target_attributes
+        assert (
+            tg_b.target_attributes["iqn.2005-10.org.freenas.ctl:HA:test2"]["rel_tgt_id"]
+            == "2"
+        )
 
     def test_parse_initiator_group_luns(self, parser):
         """Test parsing LUN assignments within initiator groups."""
-        test_config = '''
+        test_config = """
         TARGET_DRIVER iscsi {
             TARGET iqn.2024-01.com.example:test {
                 enabled 1
@@ -412,37 +429,37 @@ class TestSCSTConfigParser:
                 }
             }
         }
-        '''
+        """
         config = parser.parse_config_text(test_config)
 
         # Navigate to the initiator group
-        target = config.drivers['iscsi'].targets['iqn.2024-01.com.example:test']
-        security_group = target.groups['security_group']
+        target = config.drivers["iscsi"].targets["iqn.2024-01.com.example:test"]
+        security_group = target.groups["security_group"]
 
         # Verify it's an InitiatorGroupConfig object
         assert isinstance(security_group, InitiatorGroupConfig)
-        assert security_group.name == 'security_group'
+        assert security_group.name == "security_group"
 
         # Check LUN assignments use LunConfig objects
         luns = security_group.luns
 
-        assert '0' in luns
-        assert '1' in luns
+        assert "0" in luns
+        assert "1" in luns
 
         # Verify LunConfig objects
-        lun_0 = luns['0']
-        lun_1 = luns['1']
+        lun_0 = luns["0"]
+        lun_1 = luns["1"]
 
         assert isinstance(lun_0, LunConfig)
         assert isinstance(lun_1, LunConfig)
 
-        assert lun_0.device == 'disk1'
-        assert lun_1.device == 'disk2'
-        assert lun_1.attributes['read_only'] == '1'
+        assert lun_0.device == "disk1"
+        assert lun_1.device == "disk2"
+        assert lun_1.attributes["read_only"] == "1"
 
         # Verify initiator was parsed too
-        assert 'iqn.2023-01.com.example:server1' in security_group.initiators
+        assert "iqn.2023-01.com.example:server1" in security_group.initiators
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_parsing_errors.py
+++ b/tests/test_parsing_errors.py
@@ -17,8 +17,14 @@ def test_parsing_errors():
         ("HANDLER", "Malformed HANDLER"),
         ("TARGET_DRIVER", "Malformed TARGET_DRIVER"),
         ("TARGET_DRIVER iscsi {\n    TARGET\n}", "Malformed TARGET"),
-        ("TARGET_DRIVER iscsi {\n    TARGET test {\n        LUN\n    }\n}", "Malformed LUN"),
-        ("invalid_global = value", "Ignoring unrecognized"),  # This should be logged, not error
+        (
+            "TARGET_DRIVER iscsi {\n    TARGET test {\n        LUN\n    }\n}",
+            "Malformed LUN",
+        ),
+        (
+            "invalid_global = value",
+            "Ignoring unrecognized",
+        ),  # This should be logged, not error
         ("global_attr =", "Configuration parsing error"),  # This should fail
     ]
 
@@ -35,10 +41,12 @@ def test_parsing_errors():
             if expected_error.lower() in error_msg.lower():
                 print(f"✅ Correctly caught error: {error_msg}")
             else:
-                print(f"❌ Wrong error type. Expected '{expected_error}', got: {error_msg}")
+                print(
+                    f"❌ Wrong error type. Expected '{expected_error}', got: {error_msg}"
+                )
         except Exception as e:
             print(f"❌ Unexpected exception type: {type(e).__name__}: {e}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_parsing_errors()

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -53,36 +53,37 @@ class TestDeviceReader:
 
         # Mock the actual interface that DeviceReader uses
         mock_sysfs.SCST_DEVICES = "/sys/kernel/scst_tgt/devices"
-        mock_sysfs.list_directory.return_value = ['disk1', 'disk2', 'sda']
+        mock_sysfs.list_directory.return_value = ["disk1", "disk2", "sda"]
 
         # Mock os.path.islink for handler detection
         def mock_islink(path):
-            return path.endswith('/handler')
+            return path.endswith("/handler")
 
         # Mock os.readlink for handler type detection
         def mock_readlink(path):
-            if 'disk1' in path or 'disk2' in path:
+            if "disk1" in path or "disk2" in path:
                 return "../../handlers/vdisk_fileio"
-            elif 'sda' in path:
+            elif "sda" in path:
                 return "../../handlers/dev_disk"
             return ""
 
-        with patch('os.path.islink', side_effect=mock_islink), \
-             patch('os.readlink', side_effect=mock_readlink), \
-             patch('os.path.isfile', return_value=True):
-
+        with (
+            patch("os.path.islink", side_effect=mock_islink),
+            patch("os.readlink", side_effect=mock_readlink),
+            patch("os.path.isfile", return_value=True),
+        ):
             # Mock sysfs attribute reading
             def mock_read_attribute(path):
-                if 'filename' in path:
-                    if 'disk1' in path:
-                        return '/tmp/disk1.img'
-                    elif 'disk2' in path:
-                        return '/tmp/disk2.img'
-                    elif 'sda' in path:
-                        return '/dev/sda'
-                elif 'blocksize' in path:
-                    return '4096'
-                return ''
+                if "filename" in path:
+                    if "disk1" in path:
+                        return "/tmp/disk1.img"
+                    elif "disk2" in path:
+                        return "/tmp/disk2.img"
+                    elif "sda" in path:
+                        return "/dev/sda"
+                elif "blocksize" in path:
+                    return "4096"
+                return ""
 
             mock_sysfs.read_sysfs_attribute.side_effect = mock_read_attribute
 
@@ -91,12 +92,14 @@ class TestDeviceReader:
 
             # Verify results
             assert len(devices) == 3
-            assert 'disk1' in devices
-            assert 'disk2' in devices
-            assert 'sda' in devices
+            assert "disk1" in devices
+            assert "disk2" in devices
+            assert "sda" in devices
 
             # Verify actual interface calls
-            mock_sysfs.list_directory.assert_called_once_with("/sys/kernel/scst_tgt/devices")
+            mock_sysfs.list_directory.assert_called_once_with(
+                "/sys/kernel/scst_tgt/devices"
+            )
 
     def test_read_devices_empty_directory(self):
         """Test reading when devices directory is empty."""
@@ -108,7 +111,9 @@ class TestDeviceReader:
         devices = reader.read_devices()
 
         assert devices == {}
-        mock_sysfs.list_directory.assert_called_once_with("/sys/kernel/scst_tgt/devices")
+        mock_sysfs.list_directory.assert_called_once_with(
+            "/sys/kernel/scst_tgt/devices"
+        )
 
     def test_read_devices_sysfs_error(self):
         """Test handling sysfs directory listing errors."""
@@ -128,31 +133,35 @@ class TestDeviceReader:
         reader = DeviceReader(mock_sysfs)
 
         # Test filtered attribute reading
-        with patch('os.path.exists', return_value=True), \
-             patch('os.path.isfile', return_value=True):
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.isfile", return_value=True),
+        ):
 
             def mock_read_sysfs_attribute(path):
-                if path.endswith('/filename'):
-                    return '/tmp/test.img'
-                elif path.endswith('/blocksize'):
-                    return '4096'
-                elif path.endswith('/read_only'):
-                    return '0'
+                if path.endswith("/filename"):
+                    return "/tmp/test.img"
+                elif path.endswith("/blocksize"):
+                    return "4096"
+                elif path.endswith("/read_only"):
+                    return "0"
                 return None
 
             mock_sysfs.read_sysfs_attribute.side_effect = mock_read_sysfs_attribute
 
             # Test reading specific attributes
-            filter_attrs = {'filename', 'blocksize', 'read_only'}
-            result = reader._get_current_device_attrs('vdisk_fileio', 'disk1', filter_attrs)
+            filter_attrs = {"filename", "blocksize", "read_only"}
+            result = reader._get_current_device_attrs(
+                "vdisk_fileio", "disk1", filter_attrs
+            )
 
             # Should read the requested attributes (excluding 'handler')
-            assert 'filename' in result
-            assert result['filename'] == '/tmp/test.img'
-            assert 'blocksize' in result
-            assert result['blocksize'] == '4096'
-            assert 'read_only' in result
-            assert result['read_only'] == '0'
+            assert "filename" in result
+            assert result["filename"] == "/tmp/test.img"
+            assert "blocksize" in result
+            assert result["blocksize"] == "4096"
+            assert "read_only" in result
+            assert result["read_only"] == "0"
 
     def test_get_current_device_attrs_fallback_mode(self):
         """Test device attribute reading fallback mode (no filter)."""
@@ -161,31 +170,36 @@ class TestDeviceReader:
         reader = DeviceReader(mock_sysfs)
 
         # Test fallback mode (reads all attributes)
-        with patch('os.path.exists', return_value=True), \
-             patch('os.listdir', return_value=['filename', 'blocksize', 'read_only', 'handler']), \
-             patch('os.path.isfile', return_value=True):
+        with (
+            patch("os.path.exists", return_value=True),
+            patch(
+                "os.listdir",
+                return_value=["filename", "blocksize", "read_only", "handler"],
+            ),
+            patch("os.path.isfile", return_value=True),
+        ):
 
             def mock_read_sysfs_attribute(path):
-                if path.endswith('/filename'):
-                    return '/dev/sda1'
-                elif path.endswith('/blocksize'):
-                    return '512'
-                elif path.endswith('/read_only'):
-                    return '1'
+                if path.endswith("/filename"):
+                    return "/dev/sda1"
+                elif path.endswith("/blocksize"):
+                    return "512"
+                elif path.endswith("/read_only"):
+                    return "1"
                 return None
 
             mock_sysfs.read_sysfs_attribute.side_effect = mock_read_sysfs_attribute
 
             # Test fallback mode (no filter_attrs)
-            result = reader._get_current_device_attrs('dev_disk', 'sda1', None)
+            result = reader._get_current_device_attrs("dev_disk", "sda1", None)
 
             # Should read all available attributes
-            assert 'filename' in result
-            assert result['filename'] == '/dev/sda1'
-            assert 'blocksize' in result
-            assert result['blocksize'] == '512'
-            assert 'read_only' in result
-            assert result['read_only'] == '1'
+            assert "filename" in result
+            assert result["filename"] == "/dev/sda1"
+            assert "blocksize" in result
+            assert result["blocksize"] == "512"
+            assert "read_only" in result
+            assert result["read_only"] == "1"
 
     def test_get_current_device_attrs_error_conditions(self):
         """Test device attribute reading error handling."""
@@ -194,14 +208,16 @@ class TestDeviceReader:
         reader = DeviceReader(mock_sysfs)
 
         # Test device doesn't exist
-        with patch('os.path.exists', return_value=False):
-            result = reader._get_current_device_attrs('vdisk_fileio', 'missing_device')
+        with patch("os.path.exists", return_value=False):
+            result = reader._get_current_device_attrs("vdisk_fileio", "missing_device")
             assert result == {}
 
         # Test OSError during directory operations
-        with patch('os.path.exists', return_value=True), \
-             patch('os.listdir', side_effect=OSError("Permission denied")):
-            result = reader._get_current_device_attrs('vdisk_fileio', 'device1', None)
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.listdir", side_effect=OSError("Permission denied")),
+        ):
+            result = reader._get_current_device_attrs("vdisk_fileio", "device1", None)
             assert result == {}
 
     def test_get_current_device_attrs_skip_handler_attribute(self):
@@ -210,13 +226,15 @@ class TestDeviceReader:
         mock_sysfs.SCST_HANDLERS = "/sys/kernel/scst_tgt/handlers"
         reader = DeviceReader(mock_sysfs)
 
-        with patch('os.path.exists', return_value=True):
+        with patch("os.path.exists", return_value=True):
             # Test that 'handler' attribute is skipped (line 115-116)
-            filter_attrs = {'handler', 'filename'}
-            result = reader._get_current_device_attrs('vdisk_fileio', 'disk1', filter_attrs)
+            filter_attrs = {"handler", "filename"}
+            result = reader._get_current_device_attrs(
+                "vdisk_fileio", "disk1", filter_attrs
+            )
 
             # Should skip 'handler' attribute via continue statement
-            assert 'handler' not in result
+            assert "handler" not in result
 
     def test_safe_read_attribute(self):
         """Test safe attribute reading with various conditions."""
@@ -224,21 +242,22 @@ class TestDeviceReader:
         reader = DeviceReader(mock_sysfs)
 
         # Test successful read
-        with patch('os.path.isfile', return_value=True):
-            mock_sysfs.read_sysfs_attribute.return_value = 'test_value'
-            result = reader._safe_read_attribute('/path/to/attr')
-            assert result == 'test_value'
+        with patch("os.path.isfile", return_value=True):
+            mock_sysfs.read_sysfs_attribute.return_value = "test_value"
+            result = reader._safe_read_attribute("/path/to/attr")
+            assert result == "test_value"
 
         # Test file doesn't exist
-        with patch('os.path.isfile', return_value=False):
-            result = reader._safe_read_attribute('/missing/file')
+        with patch("os.path.isfile", return_value=False):
+            result = reader._safe_read_attribute("/missing/file")
             assert result is None
 
         # Test exception handling
-        with patch('os.path.isfile', return_value=True):
+        with patch("os.path.isfile", return_value=True):
             from scstadmin.exceptions import SCSTError
+
             mock_sysfs.read_sysfs_attribute.side_effect = SCSTError("Read failed")
-            result = reader._safe_read_attribute('/error/path')
+            result = reader._safe_read_attribute("/error/path")
             assert result is None
 
     def test_parse_mgmt_parameters(self):
@@ -253,7 +272,7 @@ The following parameters available: filename, blocksize, read_only, rotational.
         """
 
         result = reader._parse_mgmt_parameters(mgmt_content)
-        expected = {'filename', 'blocksize', 'read_only', 'rotational'}
+        expected = {"filename", "blocksize", "read_only", "rotational"}
         assert result == expected
 
         # Test no parameters available
@@ -286,11 +305,11 @@ class TestTargetReader:
 
         # Mock directory listing - provide enough responses for all calls
         mock_sysfs.list_directory.side_effect = [
-            ['iscsi', 'qla2x00t'],  # targets directory
-            ['iqn.2024-01.test:target1'],  # iscsi targets
+            ["iscsi", "qla2x00t"],  # targets directory
+            ["iqn.2024-01.test:target1"],  # iscsi targets
             [],  # iscsi target luns (empty)
-            ['21:00:00:24:ff:12:34:56'],  # qla2x00t targets
-            []   # qla2x00t target luns (empty)
+            ["21:00:00:24:ff:12:34:56"],  # qla2x00t targets
+            [],  # qla2x00t target luns (empty)
         ]
 
         # Mock path validation - TargetReader checks valid_path
@@ -298,30 +317,30 @@ class TestTargetReader:
 
         # Mock sysfs reading - TargetReader uses read_sysfs, must return strings
         def mock_read_sysfs(path):
-            if '/mgmt' in path and 'iscsi' in path:
-                return 'enabled=1\ntrace_level=0\n'
-            elif '/mgmt' in path and 'qla2x00t' in path:
-                return 'enabled=1\ntrace_level=0\n'
-            elif path.endswith('/enabled'):
-                return '1'
-            elif path.endswith('/trace_level'):
-                return '0'
-            elif 'rel_tgt_id' in path:
-                return '1'
-            elif 'isns_entity_name' in path:
-                return 'default_value'  # Return string without [key] suffix
-            return ''
+            if "/mgmt" in path and "iscsi" in path:
+                return "enabled=1\ntrace_level=0\n"
+            elif "/mgmt" in path and "qla2x00t" in path:
+                return "enabled=1\ntrace_level=0\n"
+            elif path.endswith("/enabled"):
+                return "1"
+            elif path.endswith("/trace_level"):
+                return "0"
+            elif "rel_tgt_id" in path:
+                return "1"
+            elif "isns_entity_name" in path:
+                return "default_value"  # Return string without [key] suffix
+            return ""
 
         mock_sysfs.read_sysfs.side_effect = mock_read_sysfs
 
-        with patch('os.path.isfile', return_value=True):
+        with patch("os.path.isfile", return_value=True):
             reader = TargetReader(mock_sysfs)
             drivers = reader.read_drivers()
 
             # Verify we got the expected drivers
             assert len(drivers) == 2
-            assert 'iscsi' in drivers
-            assert 'qla2x00t' in drivers
+            assert "iscsi" in drivers
+            assert "qla2x00t" in drivers
 
             # Verify interface usage
             assert mock_sysfs.list_directory.call_count >= 1
@@ -338,7 +357,9 @@ class TestTargetReader:
         drivers = reader.read_drivers()
 
         assert drivers == {}
-        mock_sysfs.list_directory.assert_called_once_with("/sys/kernel/scst_tgt/targets")
+        mock_sysfs.list_directory.assert_called_once_with(
+            "/sys/kernel/scst_tgt/targets"
+        )
 
     def test_read_drivers_with_luns(self):
         """Test reading drivers with targets that have LUN assignments."""
@@ -347,42 +368,46 @@ class TestTargetReader:
 
         # Mock directory listing for targets
         mock_sysfs.list_directory.side_effect = [
-            ['iscsi'],  # targets directory
-            ['iqn.2024-01.test:storage']  # iscsi targets (no mgmt, enabled since those are filtered)
+            ["iscsi"],  # targets directory
+            [
+                "iqn.2024-01.test:storage"
+            ],  # iscsi targets (no mgmt, enabled since those are filtered)
         ]
 
         mock_sysfs.valid_path.return_value = True
 
         # Mock sysfs reading with LUN device mappings
         def mock_read_sysfs(path):
-            if '/mgmt' in path and 'iscsi' in path:
-                return 'enabled=1\ntrace_level=0\n'
-            elif '/0/device' in path:
-                return 'disk1'
-            elif '/1/device' in path:
-                return 'disk2'
-            elif '/2/device' in path:
-                return 'disk3'
-            elif path.endswith('/enabled'):
-                return '1'
-            elif path.endswith('/read_only'):
-                return '0'
-            return ''
+            if "/mgmt" in path and "iscsi" in path:
+                return "enabled=1\ntrace_level=0\n"
+            elif "/0/device" in path:
+                return "disk1"
+            elif "/1/device" in path:
+                return "disk2"
+            elif "/2/device" in path:
+                return "disk3"
+            elif path.endswith("/enabled"):
+                return "1"
+            elif path.endswith("/read_only"):
+                return "0"
+            return ""
 
         mock_sysfs.read_sysfs.side_effect = mock_read_sysfs
 
-        with patch('os.path.isfile', return_value=True), \
-             patch('os.path.isdir', return_value=True):
+        with (
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.isdir", return_value=True),
+        ):
             reader = TargetReader(mock_sysfs)
             drivers = reader.read_drivers()
 
             # Verify we got the driver
-            assert 'iscsi' in drivers
-            iscsi_driver = drivers['iscsi']
+            assert "iscsi" in drivers
+            iscsi_driver = drivers["iscsi"]
 
             # Verify target exists (read_drivers only discovers targets, not their LUNs)
-            assert 'iqn.2024-01.test:storage' in iscsi_driver.targets
-            target = iscsi_driver.targets['iqn.2024-01.test:storage']
+            assert "iqn.2024-01.test:storage" in iscsi_driver.targets
+            target = iscsi_driver.targets["iqn.2024-01.test:storage"]
 
             # read_drivers creates minimal target configs for discovery - no LUNs populated
             assert target.luns == {}
@@ -407,21 +432,21 @@ The following target attributes available: IncomingUser, OutgoingUser, allowed_p
         mock_sysfs.read_sysfs.return_value = mgmt_content
 
         reader = TargetReader(mock_sysfs)
-        result = reader._parse_target_mgmt_interface('iscsi')
+        result = reader._parse_target_mgmt_interface("iscsi")
 
         # Verify mgmt interface was parsed with correct structure
-        assert 'create_params' in result
-        assert 'driver_attributes' in result
-        assert 'target_attributes' in result
+        assert "create_params" in result
+        assert "driver_attributes" in result
+        assert "target_attributes" in result
 
         # iSCSI has no explicit creation parameters - only target attributes
-        create_params = result['create_params']
+        create_params = result["create_params"]
         assert create_params == set()  # No "parameters available" line in iSCSI mgmt
 
         # Verify driver attributes
-        driver_attrs = result['driver_attributes']
-        assert 'enabled' in driver_attrs
-        assert 'trace_level' in driver_attrs
+        driver_attrs = result["driver_attributes"]
+        assert "enabled" in driver_attrs
+        assert "trace_level" in driver_attrs
 
     def test_read_attribute_if_non_default(self):
         """Test reading attributes with [key] suffix handling."""
@@ -429,19 +454,20 @@ The following target attributes available: IncomingUser, OutgoingUser, allowed_p
         reader = TargetReader(mock_sysfs)
 
         # Test attribute with [key] suffix (non-default value)
-        mock_sysfs.read_sysfs.return_value = 'custom_value[key]'
-        result = reader._read_attribute_if_non_default('/path/to/attr')
-        assert result == 'custom_value'
+        mock_sysfs.read_sysfs.return_value = "custom_value[key]"
+        result = reader._read_attribute_if_non_default("/path/to/attr")
+        assert result == "custom_value"
 
         # Test attribute without [key] suffix (default value)
-        mock_sysfs.read_sysfs.return_value = 'default_value'
-        result = reader._read_attribute_if_non_default('/path/to/attr')
+        mock_sysfs.read_sysfs.return_value = "default_value"
+        result = reader._read_attribute_if_non_default("/path/to/attr")
         assert result is None
 
         # Test read error - _read_attribute_if_non_default catches SCSTError
         from scstadmin.exceptions import SCSTError
+
         mock_sysfs.read_sysfs.side_effect = SCSTError("Read error")
-        result = reader._read_attribute_if_non_default('/path/to/attr')
+        result = reader._read_attribute_if_non_default("/path/to/attr")
         assert result is None
 
     def test_get_current_lun_device(self):
@@ -451,16 +477,18 @@ The following target attributes available: IncomingUser, OutgoingUser, allowed_p
 
         # Test successful LUN device reading - need to mock os operations
         mock_sysfs.SCST_TARGETS = "/sys/kernel/scst_tgt/targets"
-        with patch('os.path.exists', return_value=True), \
-             patch('os.path.islink', return_value=True), \
-             patch('os.readlink', return_value='../../../../../devices/disk1'):
-            device = reader._get_current_lun_device('iscsi', 'iqn.test:target', '0')
-            assert device == 'disk1'
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.islink", return_value=True),
+            patch("os.readlink", return_value="../../../../../devices/disk1"),
+        ):
+            device = reader._get_current_lun_device("iscsi", "iqn.test:target", "0")
+            assert device == "disk1"
 
         # Test LUN not found (path doesn't exist)
-        with patch('os.path.exists', return_value=False):
-            device = reader._get_current_lun_device('iscsi', 'iqn.test:target', '99')
-            assert device == ''
+        with patch("os.path.exists", return_value=False):
+            device = reader._get_current_lun_device("iscsi", "iqn.test:target", "99")
+            assert device == ""
 
     def test_get_target_create_params(self):
         """Test target creation parameter building."""
@@ -487,12 +515,12 @@ The following target attributes available: IncomingUser, OutgoingUser, allowed_p
 
         # Test with iSCSI target (no explicit creation parameters)
         target_attrs = {
-            'IncomingUser': 'user1:pass1',
-            'OutgoingUser': 'user2:pass2',
-            'invalid_param': 'should_be_ignored'
+            "IncomingUser": "user1:pass1",
+            "OutgoingUser": "user2:pass2",
+            "invalid_param": "should_be_ignored",
         }
 
-        params = reader._get_target_create_params('iscsi', target_attrs)
+        params = reader._get_target_create_params("iscsi", target_attrs)
 
         # iSCSI targets don't expose explicit creation parameters in mgmt interface
         # so create_params will be empty
@@ -510,18 +538,18 @@ The following parameters available: node_name, parent_host
         mock_sysfs.read_sysfs.return_value = qla_mgmt_content
 
         qla_attrs = {
-            'node_name': '20:00:00:24:ff:12:34:56',
-            'parent_host': 'host1',
-            'invalid_param': 'should_be_ignored'
+            "node_name": "20:00:00:24:ff:12:34:56",
+            "parent_host": "host1",
+            "invalid_param": "should_be_ignored",
         }
 
-        qla_params = reader._get_target_create_params('qla2x00t', qla_attrs)
+        qla_params = reader._get_target_create_params("qla2x00t", qla_attrs)
 
         # Should only include explicitly listed creation parameters
-        assert 'node_name' in qla_params
-        assert 'parent_host' in qla_params
-        assert 'invalid_param' not in qla_params
-        assert qla_params['node_name'] == '20:00:00:24:ff:12:34:56'
+        assert "node_name" in qla_params
+        assert "parent_host" in qla_params
+        assert "invalid_param" not in qla_params
+        assert qla_params["node_name"] == "20:00:00:24:ff:12:34:56"
 
     def test_safe_read_attribute_error_handling(self):
         """Test safe attribute reading with error conditions."""
@@ -529,27 +557,28 @@ The following parameters available: node_name, parent_host
         reader = TargetReader(mock_sysfs)
 
         # Test successful read - _safe_read_attribute checks os.path.isfile first
-        with patch('os.path.isfile', return_value=True):
-            mock_sysfs.read_sysfs_attribute.return_value = 'success_value'
-            result = reader._safe_read_attribute('/valid/path')
-            assert result == 'success_value'
+        with patch("os.path.isfile", return_value=True):
+            mock_sysfs.read_sysfs_attribute.return_value = "success_value"
+            result = reader._safe_read_attribute("/valid/path")
+            assert result == "success_value"
 
         # Test file doesn't exist
-        with patch('os.path.isfile', return_value=False):
-            result = reader._safe_read_attribute('/missing/path')
+        with patch("os.path.isfile", return_value=False):
+            result = reader._safe_read_attribute("/missing/path")
             assert result is None
 
         # Test read error - _safe_read_attribute catches OSError, IOError, SCSTError
-        with patch('os.path.isfile', return_value=True):
+        with patch("os.path.isfile", return_value=True):
             from scstadmin.exceptions import SCSTError
+
             mock_sysfs.read_sysfs_attribute.side_effect = SCSTError("Read failed")
-            result = reader._safe_read_attribute('/invalid/path')
+            result = reader._safe_read_attribute("/invalid/path")
             assert result is None
 
         # Test OSError handling
-        with patch('os.path.isfile', return_value=True):
+        with patch("os.path.isfile", return_value=True):
             mock_sysfs.read_sysfs_attribute.side_effect = OSError("File error")
-            result = reader._safe_read_attribute('/invalid/path')
+            result = reader._safe_read_attribute("/invalid/path")
             assert result is None
 
     def test_get_lun_create_params(self):
@@ -567,28 +596,29 @@ The following parameters available: read_only, device_name.
         mock_sysfs.read_sysfs.return_value = lun_mgmt_content
 
         lun_attrs = {
-            'read_only': '1',
-            'device_name': 'disk1',
-            'invalid_param': 'should_be_ignored'
+            "read_only": "1",
+            "device_name": "disk1",
+            "invalid_param": "should_be_ignored",
         }
 
-        result = reader._get_lun_create_params('iscsi', 'target1', lun_attrs)
+        result = reader._get_lun_create_params("iscsi", "target1", lun_attrs)
 
         # Should only include valid LUN creation parameters
-        assert 'read_only' in result
-        assert 'device_name' in result
-        assert 'invalid_param' not in result
+        assert "read_only" in result
+        assert "device_name" in result
+        assert "invalid_param" not in result
 
         # Test with invalid mgmt path
         mock_sysfs.valid_path.return_value = False
-        result = reader._get_lun_create_params('iscsi', 'target1', lun_attrs)
+        result = reader._get_lun_create_params("iscsi", "target1", lun_attrs)
         assert result == {}
 
         # Test with SCSTError during read
         mock_sysfs.valid_path.return_value = True
         from scstadmin.exceptions import SCSTError
+
         mock_sysfs.read_sysfs.side_effect = SCSTError("Read failed")
-        result = reader._get_lun_create_params('iscsi', 'target1', lun_attrs)
+        result = reader._get_lun_create_params("iscsi", "target1", lun_attrs)
         assert result == {}
 
     def test_get_current_group_lun_device(self):
@@ -598,16 +628,22 @@ The following parameters available: read_only, device_name.
         reader = TargetReader(mock_sysfs)
 
         # Test successful group LUN device reading
-        with patch('os.path.exists', return_value=True), \
-             patch('os.path.islink', return_value=True), \
-             patch('os.readlink', return_value='../../../../../devices/group_disk1'):
-            device = reader._get_current_group_lun_device('iscsi', 'target1', 'group1', '0')
-            assert device == 'group_disk1'
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.islink", return_value=True),
+            patch("os.readlink", return_value="../../../../../devices/group_disk1"),
+        ):
+            device = reader._get_current_group_lun_device(
+                "iscsi", "target1", "group1", "0"
+            )
+            assert device == "group_disk1"
 
         # Test group LUN not found
-        with patch('os.path.exists', return_value=False):
-            device = reader._get_current_group_lun_device('iscsi', 'target1', 'group1', '99')
-            assert device == ''
+        with patch("os.path.exists", return_value=False):
+            device = reader._get_current_group_lun_device(
+                "iscsi", "target1", "group1", "99"
+            )
+            assert device == ""
 
     def test_get_driver_attribute_default(self):
         """Test driver attribute default value lookup."""
@@ -615,15 +651,17 @@ The following parameters available: read_only, device_name.
         reader = TargetReader(mock_sysfs)
 
         # Test known iSCSI defaults
-        assert reader._get_driver_attribute_default('iscsi', 'link_local') == '1'
-        assert reader._get_driver_attribute_default('iscsi', 'trace_level') == '0'
-        assert reader._get_driver_attribute_default('iscsi', 'iSNSServer') == '\n'
+        assert reader._get_driver_attribute_default("iscsi", "link_local") == "1"
+        assert reader._get_driver_attribute_default("iscsi", "trace_level") == "0"
+        assert reader._get_driver_attribute_default("iscsi", "iSNSServer") == "\n"
 
         # Test unknown attribute
-        assert reader._get_driver_attribute_default('iscsi', 'unknown_attr') is None
+        assert reader._get_driver_attribute_default("iscsi", "unknown_attr") is None
 
         # Test unknown driver
-        assert reader._get_driver_attribute_default('unknown_driver', 'any_attr') is None
+        assert (
+            reader._get_driver_attribute_default("unknown_driver", "any_attr") is None
+        )
 
     def test_parse_mgmt_parameters(self):
         """Test management interface parameter parsing."""
@@ -637,7 +675,7 @@ The following parameters available: filename, blocksize, read_only.
         """
 
         result = reader._parse_mgmt_parameters(mgmt_content)
-        expected = {'filename', 'blocksize', 'read_only'}
+        expected = {"filename", "blocksize", "read_only"}
         assert result == expected
 
         # Test no parameters available
@@ -653,9 +691,10 @@ The following parameters available: filename, blocksize, read_only.
         reader = TargetReader(mock_sysfs)
 
         # Test filtered attribute reading with multi-value attributes
-        with patch('os.path.exists', return_value=True), \
-             patch('os.path.isfile', return_value=True):
-
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.isfile", return_value=True),
+        ):
             # Mock mgmt interface for attribute type detection
             mock_sysfs.valid_path.return_value = True
             mgmt_content = """Usage: echo "add_target target_name [parameters]" >mgmt
@@ -672,37 +711,37 @@ The following target attributes available: IncomingUser, OutgoingUser, enabled.
             # - /sys/.../IncomingUser2, IncomingUser3, etc.
             # The method should collect all values and join with semicolons
             def mock_read_sysfs_attribute(path):
-                if path.endswith('/IncomingUser'):
-                    return 'user1:pass1'
-                elif path.endswith('/IncomingUser1'):
-                    return 'user2:pass2'
-                elif path.endswith('/IncomingUser2'):
-                    return 'user3:pass3'
-                elif path.endswith('/enabled'):
-                    return '1'
-                elif path.endswith('/OutgoingUser'):
-                    return ''  # Empty value - will be filtered out
+                if path.endswith("/IncomingUser"):
+                    return "user1:pass1"
+                elif path.endswith("/IncomingUser1"):
+                    return "user2:pass2"
+                elif path.endswith("/IncomingUser2"):
+                    return "user3:pass3"
+                elif path.endswith("/enabled"):
+                    return "1"
+                elif path.endswith("/OutgoingUser"):
+                    return ""  # Empty value - will be filtered out
                 return None
 
             mock_sysfs.read_sysfs_attribute.side_effect = mock_read_sysfs_attribute
 
             # Test reading specific multi-value attributes
-            filter_attrs = {'IncomingUser', 'OutgoingUser', 'enabled'}
-            result = reader._get_current_target_attrs('iscsi', 'target1', filter_attrs)
+            filter_attrs = {"IncomingUser", "OutgoingUser", "enabled"}
+            result = reader._get_current_target_attrs("iscsi", "target1", filter_attrs)
 
             # Should collect multi-value IncomingUser entries
-            assert 'IncomingUser' in result
-            assert result['IncomingUser'] == 'user1:pass1;user2:pass2;user3:pass3'
+            assert "IncomingUser" in result
+            assert result["IncomingUser"] == "user1:pass1;user2:pass2;user3:pass3"
 
             # Should include enabled (non-creation param)
-            assert 'enabled' in result
-            assert result['enabled'] == '1'
+            assert "enabled" in result
+            assert result["enabled"] == "1"
 
             # Should skip creation params (node_name not included)
-            assert 'node_name' not in result
+            assert "node_name" not in result
 
             # OutgoingUser returns empty string, so gets filtered out (only non-empty values stored)
-            assert 'OutgoingUser' not in result
+            assert "OutgoingUser" not in result
 
     def test_get_current_target_attrs_fallback_mode(self):
         """Test target attribute reading fallback mode (no filter)."""
@@ -710,36 +749,47 @@ The following target attributes available: IncomingUser, OutgoingUser, enabled.
         mock_sysfs.SCST_TARGETS = "/sys/kernel/scst_tgt/targets"
         reader = TargetReader(mock_sysfs)
 
-        with patch('os.path.exists', return_value=True), \
-             patch('os.listdir', return_value=['enabled', 'luns', 'ini_groups', 'sessions', 'trace_level']), \
-             patch('os.path.isfile') as mock_isfile:
-
+        with (
+            patch("os.path.exists", return_value=True),
+            patch(
+                "os.listdir",
+                return_value=[
+                    "enabled",
+                    "luns",
+                    "ini_groups",
+                    "sessions",
+                    "trace_level",
+                ],
+            ),
+            patch("os.path.isfile") as mock_isfile,
+        ):
             # Mock os.path.isfile to return True for attribute files, False for directories
             def mock_isfile_func(path):
-                return path.endswith(('/enabled', '/trace_level'))
+                return path.endswith(("/enabled", "/trace_level"))
+
             mock_isfile.side_effect = mock_isfile_func
 
             def mock_read_sysfs_attribute(path):
-                if path.endswith('/enabled'):
-                    return '1'
-                elif path.endswith('/trace_level'):
-                    return '3'
+                if path.endswith("/enabled"):
+                    return "1"
+                elif path.endswith("/trace_level"):
+                    return "3"
                 return None
 
             mock_sysfs.read_sysfs_attribute.side_effect = mock_read_sysfs_attribute
 
             # Test fallback mode (no filter_attrs)
-            result = reader._get_current_target_attrs('iscsi', 'target1', None)
+            result = reader._get_current_target_attrs("iscsi", "target1", None)
 
             # Should read all available attributes (excluding directories)
-            assert 'enabled' in result
-            assert result['enabled'] == '1'
-            assert 'trace_level' in result
-            assert result['trace_level'] == '3'
+            assert "enabled" in result
+            assert result["enabled"] == "1"
+            assert "trace_level" in result
+            assert result["trace_level"] == "3"
 
             # Should not include directory names
-            assert 'luns' not in result
-            assert 'ini_groups' not in result
+            assert "luns" not in result
+            assert "ini_groups" not in result
 
     def test_get_current_target_attrs_error_conditions(self):
         """Test target attribute reading error handling."""
@@ -748,29 +798,33 @@ The following target attributes available: IncomingUser, OutgoingUser, enabled.
         reader = TargetReader(mock_sysfs)
 
         # Test target doesn't exist
-        with patch('os.path.exists', return_value=False):
-            result = reader._get_current_target_attrs('iscsi', 'missing_target')
+        with patch("os.path.exists", return_value=False):
+            result = reader._get_current_target_attrs("iscsi", "missing_target")
             assert result == {}
 
         # Test OSError during directory operations
-        with patch('os.path.exists', return_value=True), \
-             patch('os.listdir', side_effect=OSError("Permission denied")):
-            result = reader._get_current_target_attrs('iscsi', 'target1', None)
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.listdir", side_effect=OSError("Permission denied")),
+        ):
+            result = reader._get_current_target_attrs("iscsi", "target1", None)
             assert result == {}
 
         # Test SCSTError during attribute reading
-        with patch('os.path.exists', return_value=True), \
-             patch('os.path.isfile', return_value=True):
-
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.isfile", return_value=True),
+        ):
             mock_sysfs.valid_path.return_value = True
             mgmt_content = """The following target attributes available: enabled."""
             mock_sysfs.read_sysfs.return_value = mgmt_content
 
             from scstadmin.exceptions import SCSTError
+
             mock_sysfs.read_sysfs_attribute.side_effect = SCSTError("Read failed")
 
-            filter_attrs = {'enabled'}
-            result = reader._get_current_target_attrs('iscsi', 'target1', filter_attrs)
+            filter_attrs = {"enabled"}
+            result = reader._get_current_target_attrs("iscsi", "target1", filter_attrs)
 
             # Should handle SCSTError gracefully and continue
             assert result == {}
@@ -786,7 +840,7 @@ The following target attributes available: IncomingUser, OutgoingUser, enabled.
         mock_sysfs.SCST_TARGETS = "/sys/kernel/scst_tgt/targets"
         reader = TargetReader(mock_sysfs)
 
-        with patch('os.path.exists', return_value=True):
+        with patch("os.path.exists", return_value=True):
             # Mock mgmt interface with creation parameters
             mock_sysfs.valid_path.return_value = True
             mgmt_content = """Usage: echo "add_target target_name [parameters]" >mgmt
@@ -797,12 +851,12 @@ The following target attributes available: enabled.
             mock_sysfs.read_sysfs.return_value = mgmt_content
 
             # Request attributes including creation params - should skip them (line 240)
-            filter_attrs = {'node_name', 'parent_host', 'enabled'}
-            result = reader._get_current_target_attrs('iscsi', 'target1', filter_attrs)
+            filter_attrs = {"node_name", "parent_host", "enabled"}
+            result = reader._get_current_target_attrs("iscsi", "target1", filter_attrs)
 
             # Should skip creation params via continue statement on line 240
-            assert 'node_name' not in result
-            assert 'parent_host' not in result
+            assert "node_name" not in result
+            assert "parent_host" not in result
 
     def test_get_current_target_attrs_regular_attributes(self):
         """Test reading regular (non-multi-value) attributes - lines 272-276.
@@ -815,9 +869,10 @@ The following target attributes available: enabled.
         mock_sysfs.SCST_TARGETS = "/sys/kernel/scst_tgt/targets"
         reader = TargetReader(mock_sysfs)
 
-        with patch('os.path.exists', return_value=True), \
-             patch('os.path.isfile', return_value=True):
-
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.isfile", return_value=True),
+        ):
             # Mock mgmt interface with target attributes
             mock_sysfs.valid_path.return_value = True
             mgmt_content = """Usage: echo "add_target target_name [parameters]" >mgmt
@@ -825,15 +880,15 @@ The following target attributes available: enabled.
 The following target attributes available: IncomingUser.
             """
             mock_sysfs.read_sysfs.return_value = mgmt_content
-            mock_sysfs.read_sysfs_attribute.return_value = 'debug_value'
+            mock_sysfs.read_sysfs_attribute.return_value = "debug_value"
 
             # Request attribute that's NOT in target_attributes - triggers regular path
-            filter_attrs = {'trace_level'}  # Not in target_attributes
-            result = reader._get_current_target_attrs('iscsi', 'target1', filter_attrs)
+            filter_attrs = {"trace_level"}  # Not in target_attributes
+            result = reader._get_current_target_attrs("iscsi", "target1", filter_attrs)
 
             # Should read via regular attribute path (lines 272-276)
-            assert 'trace_level' in result
-            assert result['trace_level'] == 'debug_value'
+            assert "trace_level" in result
+            assert result["trace_level"] == "debug_value"
 
     def test_read_drivers_with_non_default_attributes(self):
         """Test driver attribute assignment when non-default values exist - line 392.
@@ -848,8 +903,8 @@ The following target attributes available: IncomingUser.
 
         # Mock directory listing
         mock_sysfs.list_directory.side_effect = [
-            ['iscsi'],  # targets directory
-            []  # no targets in iscsi
+            ["iscsi"],  # targets directory
+            [],  # no targets in iscsi
         ]
 
         mock_sysfs.valid_path.return_value = True
@@ -870,17 +925,19 @@ The following target attributes available: IncomingUser, OutgoingUser, allowed_p
 
         # Mock _read_attribute_if_non_default to return non-default value for iSNSServer
         def mock_read_non_default(path):
-            if path.endswith('/iSNSServer'):
-                return 'custom.isns.server'  # Non-default value
+            if path.endswith("/iSNSServer"):
+                return "custom.isns.server"  # Non-default value
             return None  # Default for others
 
-        with patch.object(reader, '_read_attribute_if_non_default', side_effect=mock_read_non_default):
+        with patch.object(
+            reader, "_read_attribute_if_non_default", side_effect=mock_read_non_default
+        ):
             drivers = reader.read_drivers()
 
             # Should have assigned the driver attribute (line 392)
-            iscsi_driver = drivers['iscsi']
-            assert 'iSNSServer' in iscsi_driver.attributes
-            assert iscsi_driver.attributes['iSNSServer'] == 'custom.isns.server'
+            iscsi_driver = drivers["iscsi"]
+            assert "iSNSServer" in iscsi_driver.attributes
+            assert iscsi_driver.attributes["iSNSServer"] == "custom.isns.server"
 
 
 class TestDeviceGroupReader:
@@ -901,31 +958,31 @@ class TestDeviceGroupReader:
 
         # Mock directory listing - provide enough responses for all nested calls
         mock_sysfs.list_directory.side_effect = [
-            ['production', 'development'],  # device groups
-            ['disk1', 'disk2'],  # production devices
-            ['servers'],  # production target groups
-            ['iqn.2024-01.test:target1'],  # servers target group targets
-            ['test_disk'],  # development devices
-            ['test_targets'],  # development target groups
-            ['iqn.2024-01.test:dev1']  # test_targets target group targets
+            ["production", "development"],  # device groups
+            ["disk1", "disk2"],  # production devices
+            ["servers"],  # production target groups
+            ["iqn.2024-01.test:target1"],  # servers target group targets
+            ["test_disk"],  # development devices
+            ["test_targets"],  # development target groups
+            ["iqn.2024-01.test:dev1"],  # test_targets target group targets
         ]
 
         # Mock attribute reading
         def mock_read_attribute(path):
-            if 'cpu_mask' in path:
-                return 'fff'
-            return ''
+            if "cpu_mask" in path:
+                return "fff"
+            return ""
 
         mock_sysfs.read_sysfs_attribute.side_effect = mock_read_attribute
 
-        with patch('os.path.isfile', return_value=True):
+        with patch("os.path.isfile", return_value=True):
             reader = DeviceGroupReader(mock_sysfs)
             device_groups = reader.read_device_groups()
 
             # Verify we got the expected device groups
             assert len(device_groups) == 2
-            assert 'production' in device_groups
-            assert 'development' in device_groups
+            assert "production" in device_groups
+            assert "development" in device_groups
 
             # Verify interface usage
             first_call = mock_sysfs.list_directory.call_args_list[0][0][0]
@@ -941,7 +998,9 @@ class TestDeviceGroupReader:
         device_groups = reader.read_device_groups()
 
         assert device_groups == {}
-        mock_sysfs.list_directory.assert_called_once_with("/sys/kernel/scst_tgt/device_groups")
+        mock_sysfs.list_directory.assert_called_once_with(
+            "/sys/kernel/scst_tgt/device_groups"
+        )
 
     def test_read_device_groups_with_target_attributes(self):
         """Test reading device groups with target groups that have target attributes."""
@@ -950,36 +1009,40 @@ class TestDeviceGroupReader:
 
         # Mock directory listing for complex device group structure
         mock_sysfs.list_directory.side_effect = [
-            ['production'],  # device groups
-            ['disk1', 'disk2'],  # production devices
-            ['servers'],  # production target groups
-            ['iqn.2024-01.test:target1', 'iqn.2024-01.test:target2']  # servers target group targets
+            ["production"],  # device groups
+            ["disk1", "disk2"],  # production devices
+            ["servers"],  # production target groups
+            [
+                "iqn.2024-01.test:target1",
+                "iqn.2024-01.test:target2",
+            ],  # servers target group targets
         ]
 
         mock_sysfs.valid_path.return_value = True
 
         # Mock target attribute reading - rel_tgt_id is the key attribute for targets in groups
         def mock_read_attribute(path):
-            if 'rel_tgt_id' in path:
-                if 'target1' in path:
-                    return '1'  # Target 1 has rel_tgt_id = 1
-                elif 'target2' in path:
-                    return '2'  # Target 2 has rel_tgt_id = 2
-            return ''
+            if "rel_tgt_id" in path:
+                if "target1" in path:
+                    return "1"  # Target 1 has rel_tgt_id = 1
+                elif "target2" in path:
+                    return "2"  # Target 2 has rel_tgt_id = 2
+            return ""
 
         mock_sysfs.read_sysfs_attribute.side_effect = mock_read_attribute
 
         # Mock os operations for target attribute reading (lines 84-86)
-        with patch('os.path.isdir', return_value=True), \
-             patch('os.listdir') as mock_listdir, \
-             patch('os.path.isfile', return_value=True):
-
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("os.listdir") as mock_listdir,
+            patch("os.path.isfile", return_value=True),
+        ):
             # Mock listdir for target attribute directories
             def mock_listdir_func(path):
-                if 'target1' in path:
-                    return ['rel_tgt_id', 'mgmt']  # target1 has rel_tgt_id attribute
-                elif 'target2' in path:
-                    return ['rel_tgt_id', 'mgmt']  # target2 has rel_tgt_id attribute
+                if "target1" in path:
+                    return ["rel_tgt_id", "mgmt"]  # target1 has rel_tgt_id attribute
+                elif "target2" in path:
+                    return ["rel_tgt_id", "mgmt"]  # target2 has rel_tgt_id attribute
                 return []
 
             mock_listdir.side_effect = mock_listdir_func
@@ -988,27 +1051,27 @@ class TestDeviceGroupReader:
             device_groups = reader.read_device_groups()
 
             # Verify we got the device group with target attributes
-            assert 'production' in device_groups
-            production_group = device_groups['production']
+            assert "production" in device_groups
+            production_group = device_groups["production"]
 
             # Verify target group structure
-            assert 'servers' in production_group.target_groups
-            servers_tgroup = production_group.target_groups['servers']
+            assert "servers" in production_group.target_groups
+            servers_tgroup = production_group.target_groups["servers"]
 
             # Verify targets are listed
-            assert 'iqn.2024-01.test:target1' in servers_tgroup.targets
-            assert 'iqn.2024-01.test:target2' in servers_tgroup.targets
+            assert "iqn.2024-01.test:target1" in servers_tgroup.targets
+            assert "iqn.2024-01.test:target2" in servers_tgroup.targets
 
             # Verify target attributes were read (lines 95-97)
-            assert 'iqn.2024-01.test:target1' in servers_tgroup.target_attributes
-            assert 'iqn.2024-01.test:target2' in servers_tgroup.target_attributes
+            assert "iqn.2024-01.test:target1" in servers_tgroup.target_attributes
+            assert "iqn.2024-01.test:target2" in servers_tgroup.target_attributes
 
             # Verify rel_tgt_id values were captured
-            target1_attrs = servers_tgroup.target_attributes['iqn.2024-01.test:target1']
-            target2_attrs = servers_tgroup.target_attributes['iqn.2024-01.test:target2']
+            target1_attrs = servers_tgroup.target_attributes["iqn.2024-01.test:target1"]
+            target2_attrs = servers_tgroup.target_attributes["iqn.2024-01.test:target2"]
 
-            assert target1_attrs['rel_tgt_id'] == '1'
-            assert target2_attrs['rel_tgt_id'] == '2'
+            assert target1_attrs["rel_tgt_id"] == "1"
+            assert target2_attrs["rel_tgt_id"] == "2"
 
     def test_read_device_groups_no_valid_path(self):
         """Test when device groups directory doesn't exist - line 40."""
@@ -1023,7 +1086,9 @@ class TestDeviceGroupReader:
 
         # Should return empty dict when path is invalid (line 40)
         assert device_groups == {}
-        mock_sysfs.valid_path.assert_called_once_with("/sys/kernel/scst_tgt/device_groups")
+        mock_sysfs.valid_path.assert_called_once_with(
+            "/sys/kernel/scst_tgt/device_groups"
+        )
 
     def test_read_device_groups_target_attribute_error_handling(self):
         """Test error handling during target attribute reading - lines 90-93."""
@@ -1032,34 +1097,36 @@ class TestDeviceGroupReader:
 
         # Mock directory listing
         mock_sysfs.list_directory.side_effect = [
-            ['test_group'],  # device groups
+            ["test_group"],  # device groups
             [],  # no devices
-            ['test_targets'],  # target groups
-            ['iqn.test:target1']  # targets in target group
+            ["test_targets"],  # target groups
+            ["iqn.test:target1"],  # targets in target group
         ]
 
         mock_sysfs.valid_path.return_value = True
 
-        with patch('os.path.isdir', return_value=True), \
-             patch('os.listdir', return_value=['rel_tgt_id']), \
-             patch('os.path.isfile', return_value=True):
-
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("os.listdir", return_value=["rel_tgt_id"]),
+            patch("os.path.isfile", return_value=True),
+        ):
             # Mock SCSTError during attribute reading (line 90-91)
             from scstadmin.exceptions import SCSTError
+
             mock_sysfs.read_sysfs_attribute.side_effect = SCSTError("Permission denied")
 
             reader = DeviceGroupReader(mock_sysfs)
             device_groups = reader.read_device_groups()
 
             # Should handle SCSTError gracefully and continue
-            assert 'test_group' in device_groups
-            test_group = device_groups['test_group']
-            assert 'test_targets' in test_group.target_groups
+            assert "test_group" in device_groups
+            test_group = device_groups["test_group"]
+            assert "test_targets" in test_group.target_groups
 
             # Target should be listed but no attributes stored due to read error
-            test_tgroup = test_group.target_groups['test_targets']
-            assert 'iqn.test:target1' in test_tgroup.targets
-            assert 'iqn.test:target1' not in test_tgroup.target_attributes
+            test_tgroup = test_group.target_groups["test_targets"]
+            assert "iqn.test:target1" in test_tgroup.targets
+            assert "iqn.test:target1" not in test_tgroup.target_attributes
 
     def test_read_device_groups_target_directory_error(self):
         """Test OSError during target directory operations - lines 92-93."""
@@ -1068,29 +1135,30 @@ class TestDeviceGroupReader:
 
         # Mock directory listing
         mock_sysfs.list_directory.side_effect = [
-            ['test_group'],  # device groups
+            ["test_group"],  # device groups
             [],  # no devices
-            ['test_targets'],  # target groups
-            ['iqn.test:target1']  # targets in target group
+            ["test_targets"],  # target groups
+            ["iqn.test:target1"],  # targets in target group
         ]
 
         mock_sysfs.valid_path.return_value = True
 
-        with patch('os.path.isdir', return_value=True), \
-             patch('os.listdir', side_effect=OSError("Permission denied")):
-
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("os.listdir", side_effect=OSError("Permission denied")),
+        ):
             reader = DeviceGroupReader(mock_sysfs)
             device_groups = reader.read_device_groups()
 
             # Should handle OSError gracefully during directory listing (lines 92-93)
-            assert 'test_group' in device_groups
-            test_group = device_groups['test_group']
-            assert 'test_targets' in test_group.target_groups
+            assert "test_group" in device_groups
+            test_group = device_groups["test_group"]
+            assert "test_targets" in test_group.target_groups
 
             # Target should be listed but no attributes due to directory error
-            test_tgroup = test_group.target_groups['test_targets']
-            assert 'iqn.test:target1' in test_tgroup.targets
-            assert 'iqn.test:target1' not in test_tgroup.target_attributes
+            test_tgroup = test_group.target_groups["test_targets"]
+            assert "iqn.test:target1" in test_tgroup.targets
+            assert "iqn.test:target1" not in test_tgroup.target_attributes
 
 
 class TestSCSTConfigurationReader:
@@ -1102,16 +1170,19 @@ class TestSCSTConfigurationReader:
         reader = SCSTConfigurationReader(mock_sysfs)
 
         assert reader.sysfs == mock_sysfs
-        assert hasattr(reader, 'device_reader')
-        assert hasattr(reader, 'target_reader')
-        assert hasattr(reader, 'group_reader')
+        assert hasattr(reader, "device_reader")
+        assert hasattr(reader, "target_reader")
+        assert hasattr(reader, "group_reader")
 
-    @patch('scstadmin.readers.config_reader.DeviceReader')
-    @patch('scstadmin.readers.config_reader.TargetReader')
-    @patch('scstadmin.readers.config_reader.DeviceGroupReader')
-    def test_read_current_config_integration(self, mock_group_reader_class,
-                                             mock_target_reader_class,
-                                             mock_device_reader_class):
+    @patch("scstadmin.readers.config_reader.DeviceReader")
+    @patch("scstadmin.readers.config_reader.TargetReader")
+    @patch("scstadmin.readers.config_reader.DeviceGroupReader")
+    def test_read_current_config_integration(
+        self,
+        mock_group_reader_class,
+        mock_target_reader_class,
+        mock_device_reader_class,
+    ):
         """Test full configuration reading integration."""
         mock_sysfs = Mock(spec=SCSTSysfs)
 
@@ -1124,19 +1195,19 @@ class TestSCSTConfigurationReader:
 
         # Mock directory listing for config reader's direct sysfs calls
         mock_sysfs.list_directory.side_effect = [
-            ['vdisk_fileio', 'dev_disk'],  # handlers
-            ['disk1', 'disk2'],  # devices
-            ['iscsi'],  # targets
-            ['production']  # device groups
+            ["vdisk_fileio", "dev_disk"],  # handlers
+            ["disk1", "disk2"],  # devices
+            ["iscsi"],  # targets
+            ["production"],  # device groups
         ]
 
         # Mock path validation and attribute reading
         mock_sysfs.valid_path.return_value = True
 
         def mock_read_attribute(path):
-            if 'setup_id' in path:
-                return '12345'
-            return ''
+            if "setup_id" in path:
+                return "12345"
+            return ""
 
         mock_sysfs.read_sysfs_attribute.side_effect = mock_read_attribute
 
@@ -1149,9 +1220,12 @@ class TestSCSTConfigurationReader:
         mock_target_reader_class.return_value = mock_target_reader
         mock_group_reader_class.return_value = mock_group_reader
 
-        with patch('os.path.isfile', return_value=True), \
-             patch.object(SCSTConfigurationReader, 'check_scst_available', return_value=True):
-
+        with (
+            patch("os.path.isfile", return_value=True),
+            patch.object(
+                SCSTConfigurationReader, "check_scst_available", return_value=True
+            ),
+        ):
             reader = SCSTConfigurationReader(mock_sysfs)
             config = reader.read_current_config()
 
@@ -1159,11 +1233,11 @@ class TestSCSTConfigurationReader:
             assert mock_sysfs.list_directory.call_count >= 1
 
             # Verify config structure
-            assert hasattr(config, 'devices')
-            assert hasattr(config, 'drivers')
-            assert hasattr(config, 'device_groups')
-            assert hasattr(config, 'scst_attributes')
+            assert hasattr(config, "devices")
+            assert hasattr(config, "drivers")
+            assert hasattr(config, "device_groups")
+            assert hasattr(config, "scst_attributes")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_structured_parsing.py
+++ b/tests/test_structured_parsing.py
@@ -18,7 +18,7 @@ def test_structured_device_parsing():
     parser = SCSTConfigParser()
 
     # Test basic device config parsing
-    config_text = '''
+    config_text = """
     HANDLER vdisk_fileio {
         DEVICE test_disk {
             filename /path/to/test.img
@@ -33,50 +33,54 @@ def test_structured_device_parsing():
             readonly 1
         }
     }
-    '''
+    """
 
     config = parser.parse_config_text(config_text)
 
     # Verify we have devices
     assert len(config.devices) == 2, f"Expected 2 devices, got {len(config.devices)}"
-    assert 'test_disk' in config.devices
-    assert 'physical_disk' in config.devices
+    assert "test_disk" in config.devices
+    assert "physical_disk" in config.devices
 
     # Verify device types
-    test_disk = config.devices['test_disk']
-    assert isinstance(test_disk, VdiskFileioDeviceConfig), f"Expected VdiskFileioDeviceConfig, got {type(test_disk)}"
+    test_disk = config.devices["test_disk"]
+    assert isinstance(test_disk, VdiskFileioDeviceConfig), (
+        f"Expected VdiskFileioDeviceConfig, got {type(test_disk)}"
+    )
 
-    physical_disk = config.devices['physical_disk']
-    assert isinstance(physical_disk, DevDiskDeviceConfig), f"Expected DevDiskDeviceConfig, got {type(physical_disk)}"
+    physical_disk = config.devices["physical_disk"]
+    assert isinstance(physical_disk, DevDiskDeviceConfig), (
+        f"Expected DevDiskDeviceConfig, got {type(physical_disk)}"
+    )
 
     # Verify device properties
-    assert test_disk.name == 'test_disk'
-    assert test_disk.handler_type == 'vdisk_fileio'
-    assert test_disk.filename == '/path/to/test.img'
-    assert test_disk.blocksize == '4096'
-    assert test_disk.readonly == '0'
+    assert test_disk.name == "test_disk"
+    assert test_disk.handler_type == "vdisk_fileio"
+    assert test_disk.filename == "/path/to/test.img"
+    assert test_disk.blocksize == "4096"
+    assert test_disk.readonly == "0"
 
-    assert physical_disk.name == 'physical_disk'
-    assert physical_disk.handler_type == 'dev_disk'
-    assert physical_disk.filename == '/dev/sdb'
-    assert physical_disk.readonly == '1'
+    assert physical_disk.name == "physical_disk"
+    assert physical_disk.handler_type == "dev_disk"
+    assert physical_disk.filename == "/dev/sdb"
+    assert physical_disk.readonly == "1"
 
     print("✓ Structured device parsing works correctly")
 
     # Test with basic.conf fixture
-    fixtures_dir = Path(__file__).parent / 'tests' / 'fixtures' / 'valid_configs'
-    if (fixtures_dir / 'basic.conf').exists():
+    fixtures_dir = Path(__file__).parent / "tests" / "fixtures" / "valid_configs"
+    if (fixtures_dir / "basic.conf").exists():
         print("Testing with basic.conf fixture...")
-        config = parser.parse_config_file(str(fixtures_dir / 'basic.conf'))
+        config = parser.parse_config_file(str(fixtures_dir / "basic.conf"))
 
         # Check the specific devices from basic.conf
-        assert 'disk1' in config.devices
-        assert 'disk2' in config.devices
-        assert 'sda' in config.devices
+        assert "disk1" in config.devices
+        assert "disk2" in config.devices
+        assert "sda" in config.devices
 
-        disk1 = config.devices['disk1']
-        disk2 = config.devices['disk2']
-        sda = config.devices['sda']
+        disk1 = config.devices["disk1"]
+        disk2 = config.devices["disk2"]
+        sda = config.devices["sda"]
 
         # Verify types
         assert isinstance(disk1, VdiskFileioDeviceConfig)
@@ -84,15 +88,15 @@ def test_structured_device_parsing():
         assert isinstance(sda, DevDiskDeviceConfig)
 
         # Verify attributes
-        assert disk1.filename == '/path/to/disk1.img'
-        assert disk1.blocksize == '4096'
-        assert disk1.readonly == '0'
+        assert disk1.filename == "/path/to/disk1.img"
+        assert disk1.blocksize == "4096"
+        assert disk1.readonly == "0"
 
-        assert disk2.filename == '/path with spaces/disk2.img'
-        assert disk2.blocksize == '512'
+        assert disk2.filename == "/path with spaces/disk2.img"
+        assert disk2.blocksize == "512"
 
-        assert sda.filename == '/dev/sda'
-        assert sda.handler_type == 'dev_disk'
+        assert sda.filename == "/dev/sda"
+        assert sda.handler_type == "dev_disk"
 
         print("✓ basic.conf parsing works with structured objects")
 
@@ -105,9 +109,10 @@ def main():
     except Exception as e:
         print(f"\n❌ Test failed: {e}")
         import traceback
+
         traceback.print_exc()
         return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -4,6 +4,7 @@ Test suite for SCST writer classes
 This module provides comprehensive tests for the specialized writer classes
 that handle SCST configuration application.
 """
+
 import pytest
 from unittest.mock import Mock, call, patch
 import logging
@@ -44,7 +45,9 @@ class TestDeviceWriter:
         """Create a DeviceWriter instance with mocked dependencies"""
         return DeviceWriter(mock_sysfs, mock_config_reader, mock_logger)
 
-    def test_set_device_attributes_success(self, device_writer, mock_sysfs, mock_logger):
+    def test_set_device_attributes_success(
+        self, device_writer, mock_sysfs, mock_logger
+    ):
         """
         Test successful setting of device attributes
 
@@ -57,11 +60,7 @@ class TestDeviceWriter:
         # Arrange: Set up test data
         handler = "vdisk_fileio"
         device_name = "test_disk"
-        attributes = {
-            "blocksize": "4096",
-            "readonly": "1",
-            "thin_provisioned": "0"
-        }
+        attributes = {"blocksize": "4096", "readonly": "1", "thin_provisioned": "0"}
 
         # Configure mock to simulate successful sysfs writes
         mock_sysfs.write_sysfs.return_value = None
@@ -71,12 +70,21 @@ class TestDeviceWriter:
 
         # Assert: Verify all expected sysfs write operations occurred
         expected_calls = [
-            call("/sys/kernel/scst_tgt/handlers/vdisk_fileio/test_disk/blocksize",
-                 "4096", check_result=False),
-            call("/sys/kernel/scst_tgt/handlers/vdisk_fileio/test_disk/readonly",
-                 "1", check_result=False),
-            call("/sys/kernel/scst_tgt/handlers/vdisk_fileio/test_disk/thin_provisioned",
-                 "0", check_result=False)
+            call(
+                "/sys/kernel/scst_tgt/handlers/vdisk_fileio/test_disk/blocksize",
+                "4096",
+                check_result=False,
+            ),
+            call(
+                "/sys/kernel/scst_tgt/handlers/vdisk_fileio/test_disk/readonly",
+                "1",
+                check_result=False,
+            ),
+            call(
+                "/sys/kernel/scst_tgt/handlers/vdisk_fileio/test_disk/thin_provisioned",
+                "0",
+                check_result=False,
+            ),
         ]
         mock_sysfs.write_sysfs.assert_has_calls(expected_calls, any_order=True)
 
@@ -87,7 +95,9 @@ class TestDeviceWriter:
         expected_log_calls = [
             call("Set device attribute %s.%s = %s", "test_disk", "blocksize", "4096"),
             call("Set device attribute %s.%s = %s", "test_disk", "readonly", "1"),
-            call("Set device attribute %s.%s = %s", "test_disk", "thin_provisioned", "0")
+            call(
+                "Set device attribute %s.%s = %s", "test_disk", "thin_provisioned", "0"
+            ),
         ]
         mock_logger.debug.assert_has_calls(expected_log_calls, any_order=True)
         assert mock_logger.debug.call_count == 3
@@ -95,7 +105,9 @@ class TestDeviceWriter:
         # Assert: Verify no warning logs were generated (success case)
         mock_logger.warning.assert_not_called()
 
-    def test_set_device_attributes_partial_failure(self, device_writer, mock_sysfs, mock_logger):
+    def test_set_device_attributes_partial_failure(
+        self, device_writer, mock_sysfs, mock_logger
+    ):
         """
         Test handling of partial failures when setting device attributes
 
@@ -109,9 +121,9 @@ class TestDeviceWriter:
         handler = "vdisk_fileio"
         device_name = "test_disk"
         attributes = {
-            "blocksize": "4096",      # This will succeed
-            "readonly": "1",          # This will fail
-            "thin_provisioned": "0"   # This will succeed
+            "blocksize": "4096",  # This will succeed
+            "readonly": "1",  # This will fail
+            "thin_provisioned": "0",  # This will succeed
         }
 
         # Configure mock to simulate partial failure
@@ -131,7 +143,9 @@ class TestDeviceWriter:
         # Assert: Verify debug logs for successful attributes
         successful_debug_calls = [
             call("Set device attribute %s.%s = %s", "test_disk", "blocksize", "4096"),
-            call("Set device attribute %s.%s = %s", "test_disk", "thin_provisioned", "0")
+            call(
+                "Set device attribute %s.%s = %s", "test_disk", "thin_provisioned", "0"
+            ),
         ]
         mock_logger.debug.assert_has_calls(successful_debug_calls, any_order=True)
 
@@ -144,7 +158,9 @@ class TestDeviceWriter:
         assert isinstance(actual_call[0][3], SCSTError)
         assert str(actual_call[0][3]) == "Permission denied for readonly attribute"
 
-    def test_set_device_attributes_empty_attributes(self, device_writer, mock_sysfs, mock_logger):
+    def test_set_device_attributes_empty_attributes(
+        self, device_writer, mock_sysfs, mock_logger
+    ):
         """
         Test behavior with empty attributes dictionary
 
@@ -181,7 +197,7 @@ class TestDeviceWriter:
         device_name = "test_disk"
 
         # Mock filesystem operation to return True (device exists)
-        with patch('os.path.exists', return_value=True) as mock_exists:
+        with patch("os.path.exists", return_value=True) as mock_exists:
             # Act: Call the method under test
             result = device_writer.device_exists(handler, device_name)
 
@@ -204,7 +220,7 @@ class TestDeviceWriter:
         device_name = "nonexistent_disk"
 
         # Mock filesystem operation to return False (device doesn't exist)
-        with patch('os.path.exists', return_value=False) as mock_exists:
+        with patch("os.path.exists", return_value=False) as mock_exists:
             # Act: Call the method under test
             result = device_writer.device_exists(handler, device_name)
 
@@ -235,8 +251,7 @@ class TestDeviceWriter:
 
         # Assert: Verify correct sysfs operation
         mock_sysfs.write_sysfs.assert_called_once_with(
-            "/sys/kernel/scst_tgt/handlers/vdisk_fileio/mgmt",
-            "del_device test_disk"
+            "/sys/kernel/scst_tgt/handlers/vdisk_fileio/mgmt", "del_device test_disk"
         )
 
         # Assert: Verify no error logging
@@ -264,8 +279,7 @@ class TestDeviceWriter:
 
         # Assert: Verify sysfs operation was attempted
         mock_sysfs.write_sysfs.assert_called_once_with(
-            "/sys/kernel/scst_tgt/handlers/vdisk_fileio/mgmt",
-            "del_device test_disk"
+            "/sys/kernel/scst_tgt/handlers/vdisk_fileio/mgmt", "del_device test_disk"
         )
 
         # Assert: Verify error was logged with proper context
@@ -276,7 +290,9 @@ class TestDeviceWriter:
         assert isinstance(actual_call[0][2], SCSTError)
         assert str(actual_call[0][2]) == error_message
 
-    def test_remove_device_by_name_success(self, device_writer, mock_sysfs, mock_logger):
+    def test_remove_device_by_name_success(
+        self, device_writer, mock_sysfs, mock_logger
+    ):
         """
         Test successful device removal when handler is unknown
 
@@ -296,7 +312,7 @@ class TestDeviceWriter:
             # Second call: list devices in vdisk_fileio (empty)
             [],
             # Third call: list devices in dev_disk (contains our device)
-            ["test_disk", "other_disk"]
+            ["test_disk", "other_disk"],
         ]
 
         # Configure successful sysfs write
@@ -309,20 +325,21 @@ class TestDeviceWriter:
         expected_calls = [
             call("/sys/kernel/scst_tgt/handlers"),
             call("/sys/kernel/scst_tgt/handlers/vdisk_fileio"),
-            call("/sys/kernel/scst_tgt/handlers/dev_disk")
+            call("/sys/kernel/scst_tgt/handlers/dev_disk"),
         ]
         mock_sysfs.list_directory.assert_has_calls(expected_calls)
 
         # Assert: Verify device removal from correct handler
         mock_sysfs.write_sysfs.assert_called_once_with(
-            "/sys/kernel/scst_tgt/handlers/dev_disk/mgmt",
-            "del_device test_disk"
+            "/sys/kernel/scst_tgt/handlers/dev_disk/mgmt", "del_device test_disk"
         )
 
         # Assert: Verify no error logging
         mock_logger.warning.assert_not_called()
 
-    def test_remove_device_by_name_not_found(self, device_writer, mock_sysfs, mock_logger):
+    def test_remove_device_by_name_not_found(
+        self, device_writer, mock_sysfs, mock_logger
+    ):
         """
         Test device removal when device is not found in any handler
 
@@ -341,7 +358,7 @@ class TestDeviceWriter:
             # Second call: list devices in vdisk_fileio (doesn't contain device)
             ["other_disk1"],
             # Third call: list devices in dev_disk (doesn't contain device)
-            ["other_disk2"]
+            ["other_disk2"],
         ]
 
         # Act: Call the method under test
@@ -351,7 +368,7 @@ class TestDeviceWriter:
         expected_calls = [
             call("/sys/kernel/scst_tgt/handlers"),
             call("/sys/kernel/scst_tgt/handlers/vdisk_fileio"),
-            call("/sys/kernel/scst_tgt/handlers/dev_disk")
+            call("/sys/kernel/scst_tgt/handlers/dev_disk"),
         ]
         mock_sysfs.list_directory.assert_has_calls(expected_calls)
 
@@ -361,7 +378,9 @@ class TestDeviceWriter:
         # Assert: Verify no error logging
         mock_logger.warning.assert_not_called()
 
-    def test_remove_device_by_name_sysfs_error(self, device_writer, mock_sysfs, mock_logger):
+    def test_remove_device_by_name_sysfs_error(
+        self, device_writer, mock_sysfs, mock_logger
+    ):
         """
         Test device removal when sysfs operations fail
 
@@ -387,7 +406,9 @@ class TestDeviceWriter:
         assert isinstance(actual_call[0][2], SCSTError)
         assert str(actual_call[0][2]) == "Permission denied"
 
-    def test_create_device_with_creation_params_and_attributes(self, device_writer, mock_sysfs):
+    def test_create_device_with_creation_params_and_attributes(
+        self, device_writer, mock_sysfs
+    ):
         """
         Test device creation with both creation parameters and post-creation attributes
 
@@ -405,18 +426,17 @@ class TestDeviceWriter:
             "filename": "/tmp/test.img",
             "size_mb": "1024",
             "cluster_mode": "1",  # Should be placed at end
-            "t10_dev_id": "test_disk_id"
+            "t10_dev_id": "test_disk_id",
         }
-        post_creation_attrs = {
-            "readonly": "0",
-            "rotational": "1"
-        }
+        post_creation_attrs = {"readonly": "0", "rotational": "1"}
 
         # Configure mocks
         mock_sysfs.write_sysfs.return_value = None
 
         # Act: Call the method under test
-        device_writer.create_device(handler, device_name, creation_params, post_creation_attrs)
+        device_writer.create_device(
+            handler, device_name, creation_params, post_creation_attrs
+        )
 
         # Assert: Verify device creation command was sent correctly
         # Should be at least 2 calls: 1 for device creation + N for post-creation attributes
@@ -429,7 +449,9 @@ class TestDeviceWriter:
                 creation_call = call_args
                 break
 
-        assert creation_call is not None, "Device creation call to mgmt interface not found"
+        assert creation_call is not None, (
+            "Device creation call to mgmt interface not found"
+        )
 
         # Verify correct path for device creation
         expected_handler_path = "/sys/kernel/scst_tgt/handlers/vdisk_fileio/mgmt"
@@ -445,8 +467,11 @@ class TestDeviceWriter:
 
         # Assert: Verify post-creation attribute calls were made
         # Should have calls to set readonly and rotational attributes
-        attribute_calls = [call for call in mock_sysfs.write_sysfs.call_args_list
-                           if not call[0][0].endswith("/mgmt")]
+        attribute_calls = [
+            call
+            for call in mock_sysfs.write_sysfs.call_args_list
+            if not call[0][0].endswith("/mgmt")
+        ]
         assert len(attribute_calls) == 2  # readonly and rotational
 
     def test_create_device_no_creation_params(self, device_writer, mock_sysfs):
@@ -468,7 +493,9 @@ class TestDeviceWriter:
         mock_sysfs.write_sysfs.return_value = None
 
         # Act: Call the method under test
-        device_writer.create_device(handler, device_name, creation_params, post_creation_attrs)
+        device_writer.create_device(
+            handler, device_name, creation_params, post_creation_attrs
+        )
 
         # Assert: Verify simple device creation command + attribute setting
         assert mock_sysfs.write_sysfs.call_count == 2  # 1 creation + 1 attribute
@@ -505,7 +532,9 @@ class TestDeviceWriter:
         mock_sysfs.write_sysfs.return_value = None
 
         # Act: Call the method under test
-        device_writer.create_device(handler, device_name, creation_params, post_creation_attrs)
+        device_writer.create_device(
+            handler, device_name, creation_params, post_creation_attrs
+        )
 
         # Assert: Verify only device creation command was sent (no attribute calls)
         mock_sysfs.write_sysfs.assert_called_once()
@@ -538,7 +567,7 @@ class TestDeviceWriter:
             "filename": "/shared/disk.img",
             "cluster_mode": "1",  # This should move to the end
             "t10_dev_id": "shared_disk_id",
-            "size_mb": "2048"
+            "size_mb": "2048",
         }
         post_creation_attrs = {}
 
@@ -546,7 +575,9 @@ class TestDeviceWriter:
         mock_sysfs.write_sysfs.return_value = None
 
         # Act: Call the method under test
-        device_writer.create_device(handler, device_name, creation_params, post_creation_attrs)
+        device_writer.create_device(
+            handler, device_name, creation_params, post_creation_attrs
+        )
 
         # Assert: Verify cluster_mode appears at the end
         call_args = mock_sysfs.write_sysfs.call_args
@@ -555,7 +586,7 @@ class TestDeviceWriter:
         # Split the command to analyze parameter ordering
         # Expected format: "add_device cluster_disk param1=value1;param2=value2;cluster_mode=1;"
         assert command.startswith("add_device cluster_disk ")
-        params_part = command[len("add_device cluster_disk "):]
+        params_part = command[len("add_device cluster_disk ") :]
 
         # cluster_mode should be the last parameter before the final semicolon
         assert params_part.endswith("cluster_mode=1;")
@@ -565,7 +596,9 @@ class TestDeviceWriter:
         assert "t10_dev_id=shared_disk_id" in command
         assert "size_mb=2048" in command
 
-    def test_determine_device_action_skip_matching_config(self, device_writer, mock_sysfs, mock_config_reader):
+    def test_determine_device_action_skip_matching_config(
+        self, device_writer, mock_sysfs, mock_config_reader
+    ):
         """
         Test determine_device_action returns SKIP when device config matches
 
@@ -579,16 +612,21 @@ class TestDeviceWriter:
         handler = "vdisk_fileio"
         device_name = "disk1"
         device_config = Mock()
-        device_config._CREATION_PARAMS = {'filename', 'size_mb', 'blocksize', 'cluster_mode'}
+        device_config._CREATION_PARAMS = {
+            "filename",
+            "size_mb",
+            "blocksize",
+            "cluster_mode",
+        }
         creation_params = {"filename": "/dev/sda", "size_mb": "1024"}
         post_creation_attrs = {"read_only": "1", "rotational": "0"}
 
         # Mock config reader to return matching attributes
         current_attrs = {
-            "filename": "/dev/sda",      # Creation attr matches
-            "size_mb": "1024",           # Creation attr matches
-            "read_only": "1",            # Post-creation attr matches
-            "rotational": "0"            # Post-creation attr matches
+            "filename": "/dev/sda",  # Creation attr matches
+            "size_mb": "1024",  # Creation attr matches
+            "read_only": "1",  # Post-creation attr matches
+            "rotational": "0",  # Post-creation attr matches
         }
         mock_config_reader._get_current_device_attrs.return_value = current_attrs
 
@@ -597,21 +635,29 @@ class TestDeviceWriter:
 
         # Act: Call the method under test
         result = device_writer.determine_device_action(
-            handler, device_name, device_config, creation_params, post_creation_attrs)
+            handler, device_name, device_config, creation_params, post_creation_attrs
+        )
 
         # Assert: Verify correct action returned
         assert result == ConfigAction.SKIP
 
         # Assert: Verify config reader was called correctly
         # Now checks all creation params (not just ones in config) for [key] detection
-        expected_attrs_to_check = {"filename", "size_mb", "blocksize", "cluster_mode", "read_only", "rotational"}
+        expected_attrs_to_check = {
+            "filename",
+            "size_mb",
+            "blocksize",
+            "cluster_mode",
+            "read_only",
+            "rotational",
+        }
         mock_config_reader._get_current_device_attrs.assert_called_once_with(
-            handler, device_name, expected_attrs_to_check)
+            handler, device_name, expected_attrs_to_check
+        )
 
-    def test_determine_device_action_recreate_creation_attrs_differ(self,
-                                                                    device_writer,
-                                                                    mock_sysfs,
-                                                                    mock_config_reader):
+    def test_determine_device_action_recreate_creation_attrs_differ(
+        self, device_writer, mock_sysfs, mock_config_reader
+    ):
         """
         Test determine_device_action returns RECREATE when creation attributes differ
 
@@ -625,15 +671,20 @@ class TestDeviceWriter:
         handler = "vdisk_fileio"
         device_name = "disk1"
         device_config = Mock()
-        device_config._CREATION_PARAMS = {'filename', 'size_mb', 'blocksize', 'cluster_mode'}
+        device_config._CREATION_PARAMS = {
+            "filename",
+            "size_mb",
+            "blocksize",
+            "cluster_mode",
+        }
         creation_params = {"filename": "/dev/sda", "size_mb": "2048"}  # size_mb differs
         post_creation_attrs = {"read_only": "1"}
 
         # Mock config reader - creation attr differs, post-creation matches
         current_attrs = {
-            "filename": "/dev/sda",      # Creation attr matches
-            "size_mb": "1024",           # Creation attr DIFFERS (1024 vs 2048)
-            "read_only": "1"             # Post-creation attr matches
+            "filename": "/dev/sda",  # Creation attr matches
+            "size_mb": "1024",  # Creation attr DIFFERS (1024 vs 2048)
+            "read_only": "1",  # Post-creation attr matches
         }
         mock_config_reader._get_current_device_attrs.return_value = current_attrs
 
@@ -642,18 +693,28 @@ class TestDeviceWriter:
 
         # Act: Call the method under test
         result = device_writer.determine_device_action(
-            handler, device_name, device_config, creation_params, post_creation_attrs)
+            handler, device_name, device_config, creation_params, post_creation_attrs
+        )
 
         # Assert: Verify RECREATE action returned
         assert result == ConfigAction.RECREATE
 
         # Assert: Verify attributes were checked
         # Now checks all creation params (not just ones in config) for [key] detection
-        expected_attrs_to_check = {"filename", "size_mb", "blocksize", "cluster_mode", "read_only"}
+        expected_attrs_to_check = {
+            "filename",
+            "size_mb",
+            "blocksize",
+            "cluster_mode",
+            "read_only",
+        }
         mock_config_reader._get_current_device_attrs.assert_called_once_with(
-            handler, device_name, expected_attrs_to_check)
+            handler, device_name, expected_attrs_to_check
+        )
 
-    def test_determine_device_action_update_post_attrs_differ(self, device_writer, mock_sysfs, mock_config_reader):
+    def test_determine_device_action_update_post_attrs_differ(
+        self, device_writer, mock_sysfs, mock_config_reader
+    ):
         """
         Test determine_device_action returns UPDATE when only post-creation attributes differ
 
@@ -667,16 +728,24 @@ class TestDeviceWriter:
         handler = "vdisk_fileio"
         device_name = "disk1"
         device_config = Mock()
-        device_config._CREATION_PARAMS = {'filename', 'size_mb', 'blocksize', 'cluster_mode'}
+        device_config._CREATION_PARAMS = {
+            "filename",
+            "size_mb",
+            "blocksize",
+            "cluster_mode",
+        }
         creation_params = {"filename": "/dev/sda", "size_mb": "1024"}
-        post_creation_attrs = {"read_only": "1", "rotational": "0"}  # rotational differs
+        post_creation_attrs = {
+            "read_only": "1",
+            "rotational": "0",
+        }  # rotational differs
 
         # Mock config reader - creation attrs match, post-creation differs
         current_attrs = {
-            "filename": "/dev/sda",      # Creation attr matches
-            "size_mb": "1024",           # Creation attr matches
-            "read_only": "1",            # Post-creation attr matches
-            "rotational": "1"            # Post-creation attr DIFFERS (1 vs 0)
+            "filename": "/dev/sda",  # Creation attr matches
+            "size_mb": "1024",  # Creation attr matches
+            "read_only": "1",  # Post-creation attr matches
+            "rotational": "1",  # Post-creation attr DIFFERS (1 vs 0)
         }
         mock_config_reader._get_current_device_attrs.return_value = current_attrs
 
@@ -685,22 +754,29 @@ class TestDeviceWriter:
 
         # Act: Call the method under test
         result = device_writer.determine_device_action(
-            handler, device_name, device_config, creation_params, post_creation_attrs)
+            handler, device_name, device_config, creation_params, post_creation_attrs
+        )
 
         # Assert: Verify UPDATE action returned
         assert result == ConfigAction.UPDATE
 
         # Assert: Verify attributes were checked
         # Now checks all creation params (not just ones in config) for [key] detection
-        expected_attrs_to_check = {"filename", "size_mb", "blocksize", "cluster_mode", "read_only", "rotational"}
+        expected_attrs_to_check = {
+            "filename",
+            "size_mb",
+            "blocksize",
+            "cluster_mode",
+            "read_only",
+            "rotational",
+        }
         mock_config_reader._get_current_device_attrs.assert_called_once_with(
-            handler, device_name, expected_attrs_to_check)
+            handler, device_name, expected_attrs_to_check
+        )
 
-    def test_apply_config_devices_comprehensive_workflow(self,
-                                                         device_writer,
-                                                         mock_sysfs,
-                                                         mock_config_reader,
-                                                         mock_logger):
+    def test_apply_config_devices_comprehensive_workflow(
+        self, device_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test apply_config_devices main entry point with comprehensive device workflow
 
@@ -715,24 +791,32 @@ class TestDeviceWriter:
         # Arrange: Set up test configuration with multiple scenarios
         config = Mock()
         config.devices = {
-            "skip_device": Mock(),      # Exists, config matches, will be skipped
-            "update_device": Mock(),    # Exists, post-creation attrs differ, will be updated
+            "skip_device": Mock(),  # Exists, config matches, will be skipped
+            "update_device": Mock(),  # Exists, post-creation attrs differ, will be updated
             "recreate_device": Mock(),  # Exists, creation attrs differ, will be recreated
-            "new_device": Mock()        # Doesn't exist, will be created
+            "new_device": Mock(),  # Doesn't exist, will be created
         }
 
         # Configure device configurations
         for device_name, device_config in config.devices.items():
             device_config.handler_type = "vdisk_fileio"
-            device_config.creation_attributes = {"filename": f"/dev/{device_name}", "size_mb": "1024"}
-            device_config.post_creation_attributes = {"read_only": "0", "rotational": "1"}
+            device_config.creation_attributes = {
+                "filename": f"/dev/{device_name}",
+                "size_mb": "1024",
+            }
+            device_config.post_creation_attributes = {
+                "read_only": "0",
+                "rotational": "1",
+            }
 
         # Mock device existence - only new_device doesn't exist
         def mock_device_exists(handler, device_name):
             return device_name != "new_device"
 
         # Mock device action determination
-        def mock_determine_device_action(handler, device_name, device_config, creation_params, post_attrs):
+        def mock_determine_device_action(
+            handler, device_name, device_config, creation_params, post_attrs
+        ):
             if device_name == "skip_device":
                 return ConfigAction.SKIP
             elif device_name == "update_device":
@@ -743,7 +827,9 @@ class TestDeviceWriter:
 
         # Mock helper methods
         device_writer.device_exists = Mock(side_effect=mock_device_exists)
-        device_writer.determine_device_action = Mock(side_effect=mock_determine_device_action)
+        device_writer.determine_device_action = Mock(
+            side_effect=mock_determine_device_action
+        )
         device_writer.set_device_attributes = Mock()
         device_writer.remove_device = Mock()
         device_writer.create_device = Mock()
@@ -756,53 +842,89 @@ class TestDeviceWriter:
             call("vdisk_fileio", "skip_device"),
             call("vdisk_fileio", "update_device"),
             call("vdisk_fileio", "recreate_device"),
-            call("vdisk_fileio", "new_device")
+            call("vdisk_fileio", "new_device"),
         ]
-        device_writer.device_exists.assert_has_calls(expected_exists_calls, any_order=True)
+        device_writer.device_exists.assert_has_calls(
+            expected_exists_calls, any_order=True
+        )
 
         # Assert: Verify action determination for existing devices only
         expected_action_calls = [
-            call("vdisk_fileio", "skip_device", config.devices["skip_device"],
-                 config.devices["skip_device"].creation_attributes,
-                 config.devices["skip_device"].post_creation_attributes),
-            call("vdisk_fileio", "update_device", config.devices["update_device"],
-                 config.devices["update_device"].creation_attributes,
-                 config.devices["update_device"].post_creation_attributes),
-            call("vdisk_fileio", "recreate_device", config.devices["recreate_device"],
-                 config.devices["recreate_device"].creation_attributes,
-                 config.devices["recreate_device"].post_creation_attributes)
+            call(
+                "vdisk_fileio",
+                "skip_device",
+                config.devices["skip_device"],
+                config.devices["skip_device"].creation_attributes,
+                config.devices["skip_device"].post_creation_attributes,
+            ),
+            call(
+                "vdisk_fileio",
+                "update_device",
+                config.devices["update_device"],
+                config.devices["update_device"].creation_attributes,
+                config.devices["update_device"].post_creation_attributes,
+            ),
+            call(
+                "vdisk_fileio",
+                "recreate_device",
+                config.devices["recreate_device"],
+                config.devices["recreate_device"].creation_attributes,
+                config.devices["recreate_device"].post_creation_attributes,
+            ),
         ]
-        device_writer.determine_device_action.assert_has_calls(expected_action_calls, any_order=True)
-        assert device_writer.determine_device_action.call_count == 3  # Not called for new_device
+        device_writer.determine_device_action.assert_has_calls(
+            expected_action_calls, any_order=True
+        )
+        assert (
+            device_writer.determine_device_action.call_count == 3
+        )  # Not called for new_device
 
         # Assert: Verify UPDATE action - set attributes only
         device_writer.set_device_attributes.assert_called_once_with(
-            "vdisk_fileio", "update_device",
-            config.devices["update_device"].post_creation_attributes)
+            "vdisk_fileio",
+            "update_device",
+            config.devices["update_device"].post_creation_attributes,
+        )
 
         # Assert: Verify RECREATE action - remove then create
-        device_writer.remove_device.assert_called_once_with("vdisk_fileio", "recreate_device")
+        device_writer.remove_device.assert_called_once_with(
+            "vdisk_fileio", "recreate_device"
+        )
 
         # Assert: Verify device creation for recreated and new devices
         expected_create_calls = [
-            call("vdisk_fileio", "recreate_device",
-                 config.devices["recreate_device"].creation_attributes,
-                 config.devices["recreate_device"].post_creation_attributes),
-            call("vdisk_fileio", "new_device",
-                 config.devices["new_device"].creation_attributes,
-                 config.devices["new_device"].post_creation_attributes)
+            call(
+                "vdisk_fileio",
+                "recreate_device",
+                config.devices["recreate_device"].creation_attributes,
+                config.devices["recreate_device"].post_creation_attributes,
+            ),
+            call(
+                "vdisk_fileio",
+                "new_device",
+                config.devices["new_device"].creation_attributes,
+                config.devices["new_device"].post_creation_attributes,
+            ),
         ]
-        device_writer.create_device.assert_has_calls(expected_create_calls, any_order=True)
+        device_writer.create_device.assert_has_calls(
+            expected_create_calls, any_order=True
+        )
         assert device_writer.create_device.call_count == 2
 
         # Assert: Verify debug logging
-        mock_logger.debug.assert_any_call("Applying device configurations. Found %s devices", 4)
-        mock_logger.debug.assert_any_call("Device %s already exists with matching config, skipping",
-                                          "skip_device")
-        mock_logger.debug.assert_any_call("Device %s exists, updating post-creation attributes only",
-                                          "update_device")
-        mock_logger.debug.assert_any_call("Device %s creation attributes differ, removing and recreating",
-                                          "recreate_device")
+        mock_logger.debug.assert_any_call(
+            "Applying device configurations. Found %s devices", 4
+        )
+        mock_logger.debug.assert_any_call(
+            "Device %s already exists with matching config, skipping", "skip_device"
+        )
+        mock_logger.debug.assert_any_call(
+            "Device %s exists, updating post-creation attributes only", "update_device"
+        )
+        mock_logger.debug.assert_any_call(
+            "Device %s creation attributes differ, removing and recreating",
+            "recreate_device",
+        )
 
 
 class TestTargetWriter:
@@ -826,8 +948,8 @@ class TestTargetWriter:
         mock = Mock()
         # Default mgmt info for testing
         mock._get_target_mgmt_info.return_value = {
-            'target_attributes': {'IncomingUser', 'OutgoingUser'},
-            'driver_attributes': {'MaxSessions'}
+            "target_attributes": {"IncomingUser", "OutgoingUser"},
+            "driver_attributes": {"MaxSessions"},
         }
         return mock
 
@@ -841,7 +963,9 @@ class TestTargetWriter:
         """Create a TargetWriter instance with mocked dependencies"""
         return TargetWriter(mock_sysfs, mock_config_reader, mock_logger)
 
-    def test_set_target_attributes_mgmt_attributes(self, target_writer, mock_sysfs, mock_config_reader, mock_logger):
+    def test_set_target_attributes_mgmt_attributes(
+        self, target_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test setting target attributes that use management interface commands
 
@@ -857,13 +981,13 @@ class TestTargetWriter:
         target_name = "iqn.2023-01.example.com:test"
         attributes = {
             "IncomingUser": "user1 secret123;user2 secret456",  # Multi-value mgmt attribute
-            "OutgoingUser": "outuser outpass"  # Single-value mgmt attribute
+            "OutgoingUser": "outuser outpass",  # Single-value mgmt attribute
         }
 
         # Configure mock config reader to identify these as mgmt attributes
         mock_config_reader._get_target_mgmt_info.return_value = {
-            'target_attributes': {'IncomingUser', 'OutgoingUser'},
-            'driver_attributes': set()
+            "target_attributes": {"IncomingUser", "OutgoingUser"},
+            "driver_attributes": set(),
         }
 
         # Configure successful sysfs writes
@@ -877,15 +1001,21 @@ class TestTargetWriter:
 
         # Assert: Verify correct mgmt commands were sent
         expected_calls = [
-            call("/sys/kernel/scst_tgt/targets/iscsi/mgmt",
-                 "add_target_attribute iqn.2023-01.example.com:test IncomingUser user1 secret123",
-                 check_result=False),
-            call("/sys/kernel/scst_tgt/targets/iscsi/mgmt",
-                 "add_target_attribute iqn.2023-01.example.com:test IncomingUser user2 secret456",
-                 check_result=False),
-            call("/sys/kernel/scst_tgt/targets/iscsi/mgmt",
-                 "add_target_attribute iqn.2023-01.example.com:test OutgoingUser outuser outpass",
-                 check_result=False)
+            call(
+                "/sys/kernel/scst_tgt/targets/iscsi/mgmt",
+                "add_target_attribute iqn.2023-01.example.com:test IncomingUser user1 secret123",
+                check_result=False,
+            ),
+            call(
+                "/sys/kernel/scst_tgt/targets/iscsi/mgmt",
+                "add_target_attribute iqn.2023-01.example.com:test IncomingUser user2 secret456",
+                check_result=False,
+            ),
+            call(
+                "/sys/kernel/scst_tgt/targets/iscsi/mgmt",
+                "add_target_attribute iqn.2023-01.example.com:test OutgoingUser outuser outpass",
+                check_result=False,
+            ),
         ]
         mock_sysfs.write_sysfs.assert_has_calls(expected_calls, any_order=True)
         assert mock_sysfs.write_sysfs.call_count == 3
@@ -894,18 +1024,29 @@ class TestTargetWriter:
         assert mock_logger.debug.call_count == 3
         mock_logger.debug.assert_any_call(
             "Setting target mgmt attribute %s/%s.%s = %s",
-            "iscsi", "iqn.2023-01.example.com:test", "IncomingUser", "user1 secret123"
+            "iscsi",
+            "iqn.2023-01.example.com:test",
+            "IncomingUser",
+            "user1 secret123",
         )
         mock_logger.debug.assert_any_call(
             "Setting target mgmt attribute %s/%s.%s = %s",
-            "iscsi", "iqn.2023-01.example.com:test", "IncomingUser", "user2 secret456"
+            "iscsi",
+            "iqn.2023-01.example.com:test",
+            "IncomingUser",
+            "user2 secret456",
         )
         mock_logger.debug.assert_any_call(
             "Setting target mgmt attribute %s/%s.%s = %s",
-            "iscsi", "iqn.2023-01.example.com:test", "OutgoingUser", "outuser outpass"
+            "iscsi",
+            "iqn.2023-01.example.com:test",
+            "OutgoingUser",
+            "outuser outpass",
         )
 
-    def test_set_target_attributes_direct_sysfs(self, target_writer, mock_sysfs, mock_config_reader, mock_logger):
+    def test_set_target_attributes_direct_sysfs(
+        self, target_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test setting target attributes that use direct sysfs writes
 
@@ -920,13 +1061,13 @@ class TestTargetWriter:
         target_name = "iqn.2023-01.example.com:test"
         attributes = {
             "enabled": "1",  # Direct sysfs attribute
-            "HeaderDigest": "CRC32C"  # Direct sysfs attribute
+            "HeaderDigest": "CRC32C",  # Direct sysfs attribute
         }
 
         # Configure mock config reader - these are NOT mgmt attributes
         mock_config_reader._get_target_mgmt_info.return_value = {
-            'target_attributes': set(),  # Empty - no mgmt attributes
-            'driver_attributes': set()
+            "target_attributes": set(),  # Empty - no mgmt attributes
+            "driver_attributes": set(),
         }
 
         # Configure successful sysfs writes
@@ -937,10 +1078,16 @@ class TestTargetWriter:
 
         # Assert: Verify direct sysfs writes to target attribute paths
         expected_calls = [
-            call("/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/enabled",
-                 "1", check_result=False),
-            call("/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/HeaderDigest",
-                 "CRC32C", check_result=False)
+            call(
+                "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/enabled",
+                "1",
+                check_result=False,
+            ),
+            call(
+                "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/HeaderDigest",
+                "CRC32C",
+                check_result=False,
+            ),
         ]
         mock_sysfs.write_sysfs.assert_has_calls(expected_calls, any_order=True)
         assert mock_sysfs.write_sysfs.call_count == 2
@@ -948,7 +1095,9 @@ class TestTargetWriter:
         # Assert: Verify no debug logging for direct sysfs (only mgmt gets debug logs)
         mock_logger.debug.assert_not_called()
 
-    def test_set_target_attributes_mixed_types(self, target_writer, mock_sysfs, mock_config_reader, mock_logger):
+    def test_set_target_attributes_mixed_types(
+        self, target_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test setting a mix of mgmt attributes and direct sysfs attributes
 
@@ -963,13 +1112,13 @@ class TestTargetWriter:
         attributes = {
             "IncomingUser": "user secret",  # Mgmt attribute
             "enabled": "1",  # Direct sysfs attribute
-            "HeaderDigest": "CRC32C"  # Direct sysfs attribute
+            "HeaderDigest": "CRC32C",  # Direct sysfs attribute
         }
 
         # Configure mock config reader
         mock_config_reader._get_target_mgmt_info.return_value = {
-            'target_attributes': {'IncomingUser'},  # Only IncomingUser is mgmt
-            'driver_attributes': set()
+            "target_attributes": {"IncomingUser"},  # Only IncomingUser is mgmt
+            "driver_attributes": set(),
         }
 
         # Configure successful sysfs writes
@@ -982,14 +1131,20 @@ class TestTargetWriter:
         assert mock_sysfs.write_sysfs.call_count == 3
 
         # Check for mgmt command call
-        mgmt_calls = [call for call in mock_sysfs.write_sysfs.call_args_list
-                      if call[0][0].endswith("/mgmt")]
+        mgmt_calls = [
+            call
+            for call in mock_sysfs.write_sysfs.call_args_list
+            if call[0][0].endswith("/mgmt")
+        ]
         assert len(mgmt_calls) == 1
         assert "add_target_attribute" in mgmt_calls[0][0][1]
 
         # Check for direct sysfs calls
-        direct_calls = [call for call in mock_sysfs.write_sysfs.call_args_list
-                        if not call[0][0].endswith("/mgmt")]
+        direct_calls = [
+            call
+            for call in mock_sysfs.write_sysfs.call_args_list
+            if not call[0][0].endswith("/mgmt")
+        ]
         assert len(direct_calls) == 2
 
         # Assert: Verify debug logging only for mgmt attribute
@@ -997,7 +1152,9 @@ class TestTargetWriter:
         # With %s format, attribute name is in args[3] (0=format, 1=driver, 2=target, 3=attr_name, 4=value)
         assert mock_logger.debug.call_args[0][3] == "IncomingUser"
 
-    def test_set_target_attributes_sysfs_failures(self, target_writer, mock_sysfs, mock_config_reader, mock_logger):
+    def test_set_target_attributes_sysfs_failures(
+        self, target_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test error handling when sysfs operations fail during attribute setting
 
@@ -1011,13 +1168,13 @@ class TestTargetWriter:
         target_name = "iqn.2023-01.example.com:test"
         attributes = {
             "IncomingUser": "user secret",  # This will fail
-            "enabled": "1"  # This will succeed
+            "enabled": "1",  # This will succeed
         }
 
         # Configure mock config reader
         mock_config_reader._get_target_mgmt_info.return_value = {
-            'target_attributes': {'IncomingUser'},
-            'driver_attributes': set()
+            "target_attributes": {"IncomingUser"},
+            "driver_attributes": set(),
         }
 
         # Configure mock to simulate partial failure
@@ -1046,7 +1203,9 @@ class TestTargetWriter:
         assert isinstance(actual_call[0][5], SCSTError)
         assert str(actual_call[0][5]) == "Management interface error"
 
-    def test_set_target_attributes_empty_attributes(self, target_writer, mock_sysfs, mock_config_reader, mock_logger):
+    def test_set_target_attributes_empty_attributes(
+        self, target_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test behavior with empty attributes dictionary
 
@@ -1073,7 +1232,9 @@ class TestTargetWriter:
         mock_logger.debug.assert_not_called()
         mock_logger.warning.assert_not_called()
 
-    def test_remove_target_success_with_cleanup(self, target_writer, mock_sysfs, mock_config_reader, mock_logger):
+    def test_remove_target_success_with_cleanup(
+        self, target_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test successful target removal with complete cleanup sequence
 
@@ -1091,13 +1252,20 @@ class TestTargetWriter:
 
         # Configure mock sysfs to simulate target with LUNs and groups
         mock_sysfs.valid_path.side_effect = lambda path: True  # All paths exist
-        mock_sysfs.list_directory.return_value = ["group1", "group2", "mgmt"]  # Groups with mgmt
+        mock_sysfs.list_directory.return_value = [
+            "group1",
+            "group2",
+            "mgmt",
+        ]  # Groups with mgmt
         mock_sysfs.write_sysfs.return_value = None
 
         # Mock the internal helper methods to return success
-        with patch.object(target_writer, '_disable_target_if_possible') as mock_disable, \
-             patch.object(target_writer, '_force_close_target_sessions', return_value=True) as mock_close_sessions:
-
+        with (
+            patch.object(target_writer, "_disable_target_if_possible") as mock_disable,
+            patch.object(
+                target_writer, "_force_close_target_sessions", return_value=True
+            ) as mock_close_sessions,
+        ):
             # Act: Call the method under test
             target_writer.remove_target(driver_name, target_name)
 
@@ -1109,29 +1277,55 @@ class TestTargetWriter:
 
             # Assert: Verify sysfs path validations
             expected_valid_path_calls = [
-                call("/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/luns/mgmt"),
-                call("/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups"),
-                call("/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups/group1/luns/mgmt"),
-                call("/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups/group2/luns/mgmt")
+                call(
+                    "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/luns/mgmt"
+                ),
+                call(
+                    "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups"
+                ),
+                call(
+                    "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups/group1/luns/mgmt"
+                ),
+                call(
+                    "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups/group2/luns/mgmt"
+                ),
             ]
-            mock_sysfs.valid_path.assert_has_calls(expected_valid_path_calls, any_order=True)
+            mock_sysfs.valid_path.assert_has_calls(
+                expected_valid_path_calls, any_order=True
+            )
 
             # Assert: Verify cleanup operations were performed in correct sequence
             expected_write_calls = [
                 # Clear target LUNs
-                call("/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/luns/mgmt", "clear"),
+                call(
+                    "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/luns/mgmt",
+                    "clear",
+                ),
                 # Clear group1 LUNs
-                call("/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups/group1/luns/mgmt",
-                     "clear"),
+                call(
+                    "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups/group1/luns/mgmt",
+                    "clear",
+                ),
                 # Remove group1
-                call("/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups/mgmt", "del group1"),
+                call(
+                    "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups/mgmt",
+                    "del group1",
+                ),
                 # Clear group2 LUNs
-                call("/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups/group2/luns/mgmt",
-                     "clear"),
+                call(
+                    "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups/group2/luns/mgmt",
+                    "clear",
+                ),
                 # Remove group2
-                call("/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups/mgmt", "del group2"),
+                call(
+                    "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups/mgmt",
+                    "del group2",
+                ),
                 # Remove target itself
-                call("/sys/kernel/scst_tgt/targets/iscsi/mgmt", "del_target iqn.2023-01.example.com:test")
+                call(
+                    "/sys/kernel/scst_tgt/targets/iscsi/mgmt",
+                    "del_target iqn.2023-01.example.com:test",
+                ),
             ]
             mock_sysfs.write_sysfs.assert_has_calls(expected_write_calls)
             assert mock_sysfs.write_sysfs.call_count == 6
@@ -1141,7 +1335,9 @@ class TestTargetWriter:
                 "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups"
             )
 
-    def test_remove_target_sysfs_error_handling(self, target_writer, mock_sysfs, mock_config_reader, mock_logger):
+    def test_remove_target_sysfs_error_handling(
+        self, target_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test error handling when sysfs operations fail during target removal
 
@@ -1160,9 +1356,12 @@ class TestTargetWriter:
         mock_sysfs.write_sysfs.side_effect = SCSTError("Target is in use")
 
         # Mock helper methods
-        with patch.object(target_writer, '_disable_target_if_possible') as mock_disable, \
-             patch.object(target_writer, '_force_close_target_sessions', return_value=True) as mock_close_sessions:
-
+        with (
+            patch.object(target_writer, "_disable_target_if_possible") as mock_disable,
+            patch.object(
+                target_writer, "_force_close_target_sessions", return_value=True
+            ) as mock_close_sessions,
+        ):
             # Act: Call the method under test (should not raise exception)
             target_writer.remove_target(driver_name, target_name)
 
@@ -1179,11 +1378,9 @@ class TestTargetWriter:
             mock_disable.assert_called_once_with(driver_name, target_name)
             mock_close_sessions.assert_called_once_with(driver_name, target_name)
 
-    def test_update_target_attributes_with_change_detection(self,
-                                                            target_writer,
-                                                            mock_sysfs,
-                                                            mock_config_reader,
-                                                            mock_logger):
+    def test_update_target_attributes_with_change_detection(
+        self, target_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test update_target_attributes with intelligent change detection and mgmt handling
 
@@ -1199,21 +1396,21 @@ class TestTargetWriter:
         target_name = "iqn.2023-01.example.com:test"
         desired_attrs = {
             "IncomingUser": "newuser newsecret",  # Mgmt attr, differs, needs removal+update
-            "HeaderDigest": "CRC32C",             # Direct attr, differs, needs update
-            "enabled": "1",                       # Direct attr, same, skip
-            "rotational": "0"                     # Direct attr, current is None but desired is "0", skip
+            "HeaderDigest": "CRC32C",  # Direct attr, differs, needs update
+            "enabled": "1",  # Direct attr, same, skip
+            "rotational": "0",  # Direct attr, current is None but desired is "0", skip
         }
         current_attrs = {
             "IncomingUser": "olduser oldsecret",  # Different value
-            "HeaderDigest": "None",               # Different value
-            "enabled": "1",                       # Same value
-            "rotational": None                    # None value with desired "0"
+            "HeaderDigest": "None",  # Different value
+            "enabled": "1",  # Same value
+            "rotational": None,  # None value with desired "0"
         }
 
         # Configure mock config reader to identify mgmt attributes
         mock_config_reader._get_target_mgmt_info.return_value = {
-            'target_attributes': {'IncomingUser'},  # Only IncomingUser is mgmt-managed
-            'driver_attributes': set()
+            "target_attributes": {"IncomingUser"},  # Only IncomingUser is mgmt-managed
+            "driver_attributes": set(),
         }
 
         # Mock helper methods
@@ -1221,7 +1418,9 @@ class TestTargetWriter:
         target_writer.set_target_attributes = Mock()
 
         # Act: Call the method under test
-        target_writer.update_target_attributes(driver_name, target_name, desired_attrs, current_attrs)
+        target_writer.update_target_attributes(
+            driver_name, target_name, desired_attrs, current_attrs
+        )
 
         # Assert: Verify mgmt interface was queried
         mock_config_reader._get_target_mgmt_info.assert_called_once_with(driver_name)
@@ -1234,7 +1433,7 @@ class TestTargetWriter:
         # Assert: Verify only differing attributes are updated (not enabled or rotational)
         expected_attrs_to_update = {
             "IncomingUser": "newuser newsecret",
-            "HeaderDigest": "CRC32C"
+            "HeaderDigest": "CRC32C",
         }
         target_writer.set_target_attributes.assert_called_once_with(
             driver_name, target_name, expected_attrs_to_update
@@ -1243,22 +1442,26 @@ class TestTargetWriter:
         # Assert: Verify debug logging for attribute comparisons
         mock_logger.debug.assert_any_call(
             "Target attribute '%s' needs update: current='%s' -> desired='%s'",
-            "IncomingUser", "olduser oldsecret", "newuser newsecret"
+            "IncomingUser",
+            "olduser oldsecret",
+            "newuser newsecret",
         )
         mock_logger.debug.assert_any_call(
             "Target attribute '%s' needs update: current='%s' -> desired='%s'",
-            "HeaderDigest", "None", "CRC32C"
+            "HeaderDigest",
+            "None",
+            "CRC32C",
         )
         mock_logger.debug.assert_any_call(
             "Updating %s target attributes for %s/%s",
-            2, "iscsi", "iqn.2023-01.example.com:test"
+            2,
+            "iscsi",
+            "iqn.2023-01.example.com:test",
         )
 
-    def test_apply_config_assignments_comprehensive_workflow(self,
-                                                             target_writer,
-                                                             mock_sysfs,
-                                                             mock_config_reader,
-                                                             mock_logger):
+    def test_apply_config_assignments_comprehensive_workflow(
+        self, target_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test apply_config_assignments with comprehensive target configuration workflow
 
@@ -1272,15 +1475,13 @@ class TestTargetWriter:
         """
         # Arrange: Set up test configuration
         config = Mock()
-        config.drivers = {
-            "iscsi": Mock()
-        }
+        config.drivers = {"iscsi": Mock()}
 
         # Configure driver with two targets: one existing, one new
         driver_config = config.drivers["iscsi"]
         driver_config.targets = {
             "existing_target": Mock(),  # Exists, will be updated
-            "new_target": Mock()        # Doesn't exist, will be created
+            "new_target": Mock(),  # Doesn't exist, will be created
         }
 
         # Configure existing target (attributes differ, groups differ)
@@ -1297,10 +1498,18 @@ class TestTargetWriter:
 
         # Mock helper methods with specific return values
         target_writer._target_exists = Mock(side_effect=mock_target_exists)
-        target_writer._target_config_differs = Mock(return_value=True)  # Attributes differ
-        target_writer._direct_lun_assignments_differ = Mock(return_value=False)  # LUNs match
-        target_writer._group_lun_assignments_differ = Mock(return_value=False)  # Group LUNs match
-        target_writer._group_assignments_differ = Mock(return_value=True)  # Groups differ
+        target_writer._target_config_differs = Mock(
+            return_value=True
+        )  # Attributes differ
+        target_writer._direct_lun_assignments_differ = Mock(
+            return_value=False
+        )  # LUNs match
+        target_writer._group_lun_assignments_differ = Mock(
+            return_value=False
+        )  # Group LUNs match
+        target_writer._group_assignments_differ = Mock(
+            return_value=True
+        )  # Groups differ
         target_writer.update_target_attributes = Mock()
         target_writer._update_target_groups = Mock()
         target_writer.ensure_hardware_targets_enabled = Mock()
@@ -1309,10 +1518,13 @@ class TestTargetWriter:
         target_writer.apply_group_assignments = Mock()
 
         # Mock config reader methods
-        mock_config_reader._get_current_target_attrs.return_value = {"HeaderDigest": "None", "enabled": "1"}
+        mock_config_reader._get_current_target_attrs.return_value = {
+            "HeaderDigest": "None",
+            "enabled": "1",
+        }
         mock_config_reader._get_target_mgmt_info.return_value = {
             "create_params": {"node_name"},
-            "target_attributes": {"IncomingUser", "OutgoingUser"}
+            "target_attributes": {"IncomingUser", "OutgoingUser"},
         }
 
         # Mock _get_target_create_params to return creation params for new_target only
@@ -1320,7 +1532,10 @@ class TestTargetWriter:
             if "node_name" in attrs:
                 return {"node_name": attrs["node_name"]}
             return {}
-        mock_config_reader._get_target_create_params.side_effect = mock_get_create_params
+
+        mock_config_reader._get_target_create_params.side_effect = (
+            mock_get_create_params
+        )
 
         # Configure successful sysfs writes
         mock_sysfs.write_sysfs.return_value = None
@@ -1331,9 +1546,11 @@ class TestTargetWriter:
         # Assert: Verify target existence checks
         expected_exists_calls = [
             call("iscsi", "existing_target"),
-            call("iscsi", "new_target")
+            call("iscsi", "new_target"),
         ]
-        target_writer._target_exists.assert_has_calls(expected_exists_calls, any_order=True)
+        target_writer._target_exists.assert_has_calls(
+            expected_exists_calls, any_order=True
+        )
 
         # Assert: Verify existing target updates
         # Attributes should be updated (they differ)
@@ -1344,24 +1561,36 @@ class TestTargetWriter:
         )
 
         # Assert: Verify new target creation
-        target_writer.ensure_hardware_targets_enabled.assert_called_once_with("iscsi", driver_config)
+        target_writer.ensure_hardware_targets_enabled.assert_called_once_with(
+            "iscsi", driver_config
+        )
         mock_sysfs.write_sysfs.assert_called_with(
             "/sys/kernel/scst_tgt/targets/iscsi/mgmt",
-            "add_target new_target node_name=iqn.example:new"
+            "add_target new_target node_name=iqn.example:new",
         )
 
         # Assert: Verify post-creation attribute setting for new target
         target_writer.set_target_attributes.assert_called_once_with(
-            "iscsi", "new_target", {"enabled": "1"}  # node_name excluded as creation param
+            "iscsi",
+            "new_target",
+            {"enabled": "1"},  # node_name excluded as creation param
         )
 
         # Assert: Verify LUN and group assignments applied for new target
-        target_writer.apply_lun_assignments.assert_called_with("iscsi", "new_target", new_target)
-        target_writer.apply_group_assignments.assert_called_with("iscsi", "new_target", new_target)
+        target_writer.apply_lun_assignments.assert_called_with(
+            "iscsi", "new_target", new_target
+        )
+        target_writer.apply_group_assignments.assert_called_with(
+            "iscsi", "new_target", new_target
+        )
 
         # Assert: Verify debug logging
-        mock_logger.debug.assert_any_call("Target attributes differ for %s/%s, updating", "iscsi", "existing_target")
-        mock_logger.debug.assert_any_call("Group assignments differ for %s/%s, updating", "iscsi", "existing_target")
+        mock_logger.debug.assert_any_call(
+            "Target attributes differ for %s/%s, updating", "iscsi", "existing_target"
+        )
+        mock_logger.debug.assert_any_call(
+            "Group assignments differ for %s/%s, updating", "iscsi", "existing_target"
+        )
 
     def test_target_exists_true(self, target_writer, mock_sysfs):
         """
@@ -1377,7 +1606,7 @@ class TestTargetWriter:
         target_name = "iqn.2023-01.example.com:test"
 
         # Mock filesystem operation to return True (target exists)
-        with patch('os.path.exists', return_value=True) as mock_exists:
+        with patch("os.path.exists", return_value=True) as mock_exists:
             # Act: Call the method under test
             result = target_writer._target_exists(driver, target_name)
 
@@ -1401,7 +1630,7 @@ class TestTargetWriter:
         target_name = "20:00:00:25:B5:00:00:00"
 
         # Mock filesystem operation to return False (target doesn't exist)
-        with patch('os.path.exists', return_value=False) as mock_exists:
+        with patch("os.path.exists", return_value=False) as mock_exists:
             # Act: Call the method under test
             result = target_writer._target_exists(driver, target_name)
 
@@ -1427,7 +1656,10 @@ class TestTargetWriter:
         target = "iqn.2023-01.example.com:test"
         group_name = "windows_clients"
         group_config = Mock()
-        group_config.initiators = ["iqn.1991-05.com.microsoft:client1", "iqn.1991-05.com.microsoft:client2"]
+        group_config.initiators = [
+            "iqn.1991-05.com.microsoft:client1",
+            "iqn.1991-05.com.microsoft:client2",
+        ]
         group_config.luns = {"0": {}, "1": {}}  # LUN numbers as keys
 
         group_path = "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups/windows_clients"
@@ -1440,7 +1672,11 @@ class TestTargetWriter:
 
         def mock_listdir(path):
             if path == initiators_path:
-                return ["iqn.1991-05.com.microsoft:client1", "iqn.1991-05.com.microsoft:client2", "mgmt"]
+                return [
+                    "iqn.1991-05.com.microsoft:client1",
+                    "iqn.1991-05.com.microsoft:client2",
+                    "mgmt",
+                ]
             elif path == luns_path:
                 return ["0", "1", "mgmt"]  # LUN directories
             return []
@@ -1453,18 +1689,23 @@ class TestTargetWriter:
             # LUN entries are directories, mgmt is excluded
             return "luns/" in path and not path.endswith("/mgmt")
 
-        with patch('os.path.exists', side_effect=mock_exists), \
-             patch('os.listdir', side_effect=mock_listdir), \
-             patch('os.path.isfile', side_effect=mock_isfile), \
-             patch('os.path.isdir', side_effect=mock_isdir):
-
+        with (
+            patch("os.path.exists", side_effect=mock_exists),
+            patch("os.listdir", side_effect=mock_listdir),
+            patch("os.path.isfile", side_effect=mock_isfile),
+            patch("os.path.isdir", side_effect=mock_isdir),
+        ):
             # Act: Call the method under test
-            result = target_writer._group_config_matches(driver, target, group_name, group_config)
+            result = target_writer._group_config_matches(
+                driver, target, group_name, group_config
+            )
 
         # Assert: Verify method returns True for matching configuration
         assert result is True
 
-    def test_group_config_matches_false_initiators_differ(self, target_writer, mock_sysfs):
+    def test_group_config_matches_false_initiators_differ(
+        self, target_writer, mock_sysfs
+    ):
         """
         Test _group_config_matches returns False when initiator lists differ
 
@@ -1479,7 +1720,10 @@ class TestTargetWriter:
         target = "iqn.2023-01.example.com:test"
         group_name = "linux_clients"
         group_config = Mock()
-        group_config.initiators = ["iqn.1993-08.org.debian:client1", "iqn.1993-08.org.debian:client2"]
+        group_config.initiators = [
+            "iqn.1993-08.org.debian:client1",
+            "iqn.1993-08.org.debian:client2",
+        ]
         group_config.luns = {"0": {}}
 
         group_path = "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups/linux_clients"
@@ -1491,18 +1735,25 @@ class TestTargetWriter:
 
         def mock_listdir(path):
             if path == initiators_path:
-                return ["iqn.1993-08.org.debian:client1", "iqn.1993-08.org.debian:different_client", "mgmt"]
+                return [
+                    "iqn.1993-08.org.debian:client1",
+                    "iqn.1993-08.org.debian:different_client",
+                    "mgmt",
+                ]
             return []
 
         def mock_isfile(path):
             return "initiators/" in path and not path.endswith("/mgmt")
 
-        with patch('os.path.exists', side_effect=mock_exists), \
-             patch('os.listdir', side_effect=mock_listdir), \
-             patch('os.path.isfile', side_effect=mock_isfile):
-
+        with (
+            patch("os.path.exists", side_effect=mock_exists),
+            patch("os.listdir", side_effect=mock_listdir),
+            patch("os.path.isfile", side_effect=mock_isfile),
+        ):
             # Act: Call the method under test
-            result = target_writer._group_config_matches(driver, target, group_name, group_config)
+            result = target_writer._group_config_matches(
+                driver, target, group_name, group_config
+            )
 
         # Assert: Verify method returns False for differing initiators
         assert result is False
@@ -1537,7 +1788,11 @@ class TestTargetWriter:
             if path == initiators_path:
                 return ["iqn.example:client1", "mgmt"]  # Matching initiators
             elif path == luns_path:
-                return ["0", "2", "mgmt"]  # Current LUNs: 0, 2 (differs from desired 0, 1)
+                return [
+                    "0",
+                    "2",
+                    "mgmt",
+                ]  # Current LUNs: 0, 2 (differs from desired 0, 1)
             return []
 
         def mock_isfile(path):
@@ -1546,18 +1801,23 @@ class TestTargetWriter:
         def mock_isdir(path):
             return "luns/" in path and not path.endswith("/mgmt")
 
-        with patch('os.path.exists', side_effect=mock_exists), \
-             patch('os.listdir', side_effect=mock_listdir), \
-             patch('os.path.isfile', side_effect=mock_isfile), \
-             patch('os.path.isdir', side_effect=mock_isdir):
-
+        with (
+            patch("os.path.exists", side_effect=mock_exists),
+            patch("os.listdir", side_effect=mock_listdir),
+            patch("os.path.isfile", side_effect=mock_isfile),
+            patch("os.path.isdir", side_effect=mock_isdir),
+        ):
             # Act: Call the method under test
-            result = target_writer._group_config_matches(driver, target, group_name, group_config)
+            result = target_writer._group_config_matches(
+                driver, target, group_name, group_config
+            )
 
         # Assert: Verify method returns False for differing LUN assignments
         assert result is False
 
-    def test_group_assignments_differ_false_matching_config(self, target_writer, mock_sysfs):
+    def test_group_assignments_differ_false_matching_config(
+        self, target_writer, mock_sysfs
+    ):
         """
         Test _group_assignments_differ returns False when group assignments match
 
@@ -1572,12 +1832,11 @@ class TestTargetWriter:
         driver = "iscsi"
         target = "iqn.2023-01.example.com:test"
         target_config = Mock()
-        target_config.groups = {
-            "windows_clients": Mock(),
-            "linux_clients": Mock()
-        }
+        target_config.groups = {"windows_clients": Mock(), "linux_clients": Mock()}
 
-        groups_path = "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups"
+        groups_path = (
+            "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups"
+        )
 
         # Mock filesystem operations
         def mock_exists(path):
@@ -1585,7 +1844,11 @@ class TestTargetWriter:
 
         def mock_listdir(path):
             if path == groups_path:
-                return ["windows_clients", "linux_clients", "mgmt"]  # Current groups match desired
+                return [
+                    "windows_clients",
+                    "linux_clients",
+                    "mgmt",
+                ]  # Current groups match desired
             return []
 
         def mock_isdir(path):
@@ -1594,14 +1857,19 @@ class TestTargetWriter:
 
         # Mock helper methods to return matching configurations
         target_writer._group_exists = Mock(return_value=True)
-        target_writer._group_config_matches = Mock(return_value=True)  # All groups match
+        target_writer._group_config_matches = Mock(
+            return_value=True
+        )  # All groups match
 
-        with patch('os.path.exists', side_effect=mock_exists), \
-             patch('os.listdir', side_effect=mock_listdir), \
-             patch('os.path.isdir', side_effect=mock_isdir):
-
+        with (
+            patch("os.path.exists", side_effect=mock_exists),
+            patch("os.listdir", side_effect=mock_listdir),
+            patch("os.path.isdir", side_effect=mock_isdir),
+        ):
             # Act: Call the method under test
-            result = target_writer._group_assignments_differ(driver, target, target_config)
+            result = target_writer._group_assignments_differ(
+                driver, target, target_config
+            )
 
         # Assert: Verify method returns False for matching assignments
         assert result is False
@@ -1609,17 +1877,30 @@ class TestTargetWriter:
         # Assert: Verify group existence and config matching checks
         expected_exists_calls = [
             call(driver, target, "windows_clients"),
-            call(driver, target, "linux_clients")
+            call(driver, target, "linux_clients"),
         ]
-        target_writer._group_exists.assert_has_calls(expected_exists_calls, any_order=True)
+        target_writer._group_exists.assert_has_calls(
+            expected_exists_calls, any_order=True
+        )
 
         expected_config_calls = [
-            call(driver, target, "windows_clients", target_config.groups["windows_clients"]),
-            call(driver, target, "linux_clients", target_config.groups["linux_clients"])
+            call(
+                driver,
+                target,
+                "windows_clients",
+                target_config.groups["windows_clients"],
+            ),
+            call(
+                driver, target, "linux_clients", target_config.groups["linux_clients"]
+            ),
         ]
-        target_writer._group_config_matches.assert_has_calls(expected_config_calls, any_order=True)
+        target_writer._group_config_matches.assert_has_calls(
+            expected_config_calls, any_order=True
+        )
 
-    def test_group_assignments_differ_true_group_membership_differs(self, target_writer, mock_sysfs):
+    def test_group_assignments_differ_true_group_membership_differs(
+        self, target_writer, mock_sysfs
+    ):
         """
         Test _group_assignments_differ returns True when group membership differs
 
@@ -1635,10 +1916,12 @@ class TestTargetWriter:
         target_config = Mock()
         target_config.groups = {
             "windows_clients": Mock(),
-            "mac_clients": Mock()  # Desired: windows_clients, mac_clients
+            "mac_clients": Mock(),  # Desired: windows_clients, mac_clients
         }
 
-        groups_path = "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups"
+        groups_path = (
+            "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups"
+        )
 
         # Mock filesystem operations - different current groups
         def mock_exists(path):
@@ -1646,7 +1929,11 @@ class TestTargetWriter:
 
         def mock_listdir(path):
             if path == groups_path:
-                return ["windows_clients", "linux_clients", "mgmt"]  # Current: windows_clients, linux_clients
+                return [
+                    "windows_clients",
+                    "linux_clients",
+                    "mgmt",
+                ]  # Current: windows_clients, linux_clients
             return []
 
         def mock_isdir(path):
@@ -1656,12 +1943,15 @@ class TestTargetWriter:
         target_writer._group_exists = Mock()
         target_writer._group_config_matches = Mock()
 
-        with patch('os.path.exists', side_effect=mock_exists), \
-             patch('os.listdir', side_effect=mock_listdir), \
-             patch('os.path.isdir', side_effect=mock_isdir):
-
+        with (
+            patch("os.path.exists", side_effect=mock_exists),
+            patch("os.listdir", side_effect=mock_listdir),
+            patch("os.path.isdir", side_effect=mock_isdir),
+        ):
             # Act: Call the method under test
-            result = target_writer._group_assignments_differ(driver, target, target_config)
+            result = target_writer._group_assignments_differ(
+                driver, target, target_config
+            )
 
         # Assert: Verify method returns True for differing group membership
         assert result is True
@@ -1670,7 +1960,9 @@ class TestTargetWriter:
         target_writer._group_exists.assert_not_called()
         target_writer._group_config_matches.assert_not_called()
 
-    def test_group_assignments_differ_true_group_config_differs(self, target_writer, mock_sysfs):
+    def test_group_assignments_differ_true_group_config_differs(
+        self, target_writer, mock_sysfs
+    ):
         """
         Test _group_assignments_differ returns True when group configuration differs
 
@@ -1684,12 +1976,11 @@ class TestTargetWriter:
         driver = "iscsi"
         target = "iqn.2023-01.example.com:test"
         target_config = Mock()
-        target_config.groups = {
-            "storage_group": Mock(),
-            "backup_group": Mock()
-        }
+        target_config.groups = {"storage_group": Mock(), "backup_group": Mock()}
 
-        groups_path = "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups"
+        groups_path = (
+            "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups"
+        )
 
         # Mock filesystem operations - matching group membership
         def mock_exists(path):
@@ -1697,7 +1988,11 @@ class TestTargetWriter:
 
         def mock_listdir(path):
             if path == groups_path:
-                return ["storage_group", "backup_group", "mgmt"]  # Current groups match desired
+                return [
+                    "storage_group",
+                    "backup_group",
+                    "mgmt",
+                ]  # Current groups match desired
             return []
 
         def mock_isdir(path):
@@ -1710,14 +2005,20 @@ class TestTargetWriter:
             if group_name == "storage_group":
                 return False  # First group differs
             return True  # Other groups match (but shouldn't be checked due to early return)
-        target_writer._group_config_matches = Mock(side_effect=mock_group_config_matches)
 
-        with patch('os.path.exists', side_effect=mock_exists), \
-             patch('os.listdir', side_effect=mock_listdir), \
-             patch('os.path.isdir', side_effect=mock_isdir):
+        target_writer._group_config_matches = Mock(
+            side_effect=mock_group_config_matches
+        )
 
+        with (
+            patch("os.path.exists", side_effect=mock_exists),
+            patch("os.listdir", side_effect=mock_listdir),
+            patch("os.path.isdir", side_effect=mock_isdir),
+        ):
             # Act: Call the method under test
-            result = target_writer._group_assignments_differ(driver, target, target_config)
+            result = target_writer._group_assignments_differ(
+                driver, target, target_config
+            )
 
         # Assert: Verify method returns True for differing group configuration
         assert result is True
@@ -1732,11 +2033,9 @@ class TestTargetWriter:
         # At least one group config should be checked, and method returns on first difference
         assert target_writer._group_config_matches.call_count >= 1
 
-    def test_apply_group_assignments_comprehensive_workflow(self,
-                                                            target_writer,
-                                                            mock_sysfs,
-                                                            mock_config_reader,
-                                                            mock_logger):
+    def test_apply_group_assignments_comprehensive_workflow(
+        self, target_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test apply_group_assignments with comprehensive group configuration workflow
 
@@ -1754,8 +2053,8 @@ class TestTargetWriter:
         target_config = Mock()
         target_config.groups = {
             "existing_group": Mock(),  # Exists with matching config, will be skipped
-            "update_group": Mock(),    # Exists but config differs, will be updated
-            "new_group": Mock()        # Doesn't exist, will be created
+            "update_group": Mock(),  # Exists but config differs, will be updated
+            "new_group": Mock(),  # Doesn't exist, will be created
         }
 
         # Configure existing group (matching config)
@@ -1766,7 +2065,10 @@ class TestTargetWriter:
 
         # Configure update group (differing config)
         update_group = target_config.groups["update_group"]
-        update_group.initiators = ["iqn.example:client2", "iqn.example:client\\#3"]  # Test escaping
+        update_group.initiators = [
+            "iqn.example:client2",
+            "iqn.example:client\\#3",
+        ]  # Test escaping
         update_group.luns = {"0": Mock(), "1": Mock()}
         update_group.luns["0"].device = "disk1"
         update_group.luns["1"].device = "disk2"
@@ -1785,7 +2087,9 @@ class TestTargetWriter:
             return group_name == "existing_group"  # Only existing_group matches
 
         target_writer._group_exists = Mock(side_effect=mock_group_exists)
-        target_writer._group_config_matches = Mock(side_effect=mock_group_config_matches)
+        target_writer._group_config_matches = Mock(
+            side_effect=mock_group_config_matches
+        )
 
         # Configure successful sysfs writes
         mock_sysfs.write_sysfs.return_value = None
@@ -1797,36 +2101,53 @@ class TestTargetWriter:
         expected_exists_calls = [
             call(driver, target, "existing_group"),
             call(driver, target, "update_group"),
-            call(driver, target, "new_group")
+            call(driver, target, "new_group"),
         ]
-        target_writer._group_exists.assert_has_calls(expected_exists_calls, any_order=True)
+        target_writer._group_exists.assert_has_calls(
+            expected_exists_calls, any_order=True
+        )
 
         expected_config_calls = [
             call(driver, target, "existing_group", existing_group),
-            call(driver, target, "update_group", update_group)
+            call(driver, target, "update_group", update_group),
             # new_group not checked because it doesn't exist
         ]
-        target_writer._group_config_matches.assert_has_calls(expected_config_calls, any_order=True)
+        target_writer._group_config_matches.assert_has_calls(
+            expected_config_calls, any_order=True
+        )
 
         # Assert: Verify group creation calls
         base_mgmt_path = "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups/mgmt"
         expected_create_calls = [
             call(base_mgmt_path, "create update_group"),
-            call(base_mgmt_path, "create new_group")
+            call(base_mgmt_path, "create new_group"),
             # existing_group not created (skipped due to matching config)
         ]
         mock_sysfs.write_sysfs.assert_has_calls(expected_create_calls, any_order=True)
 
         # Assert: Verify initiator assignments (with escaping)
-        base_initiators_path = "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups"
+        base_initiators_path = (
+            "/sys/kernel/scst_tgt/targets/iscsi/iqn.2023-01.example.com:test/ini_groups"
+        )
         expected_initiator_calls = [
             # update_group initiators - client#3, escaping removed
-            call(f"{base_initiators_path}/update_group/initiators/mgmt", "add iqn.example:client2"),
-            call(f"{base_initiators_path}/update_group/initiators/mgmt", "add iqn.example:client#3"),
+            call(
+                f"{base_initiators_path}/update_group/initiators/mgmt",
+                "add iqn.example:client2",
+            ),
+            call(
+                f"{base_initiators_path}/update_group/initiators/mgmt",
+                "add iqn.example:client#3",
+            ),
             # new_group initiators
-            call(f"{base_initiators_path}/new_group/initiators/mgmt", "add iqn.example:client4")
+            call(
+                f"{base_initiators_path}/new_group/initiators/mgmt",
+                "add iqn.example:client4",
+            ),
         ]
-        mock_sysfs.write_sysfs.assert_has_calls(expected_initiator_calls, any_order=True)
+        mock_sysfs.write_sysfs.assert_has_calls(
+            expected_initiator_calls, any_order=True
+        )
 
         # Assert: Verify LUN assignments
         expected_lun_calls = [
@@ -1834,29 +2155,39 @@ class TestTargetWriter:
             call(f"{base_initiators_path}/update_group/luns/mgmt", "add disk1 0"),
             call(f"{base_initiators_path}/update_group/luns/mgmt", "add disk2 1"),
             # new_group LUNs
-            call(f"{base_initiators_path}/new_group/luns/mgmt", "add disk3 0")
+            call(f"{base_initiators_path}/new_group/luns/mgmt", "add disk3 0"),
         ]
         mock_sysfs.write_sysfs.assert_has_calls(expected_lun_calls, any_order=True)
 
         # Assert: Verify debug logging
         mock_logger.debug.assert_any_call(
             "Group %s for %s/%s already exists with matching config, skipping",
-            "existing_group", "iscsi", "iqn.2023-01.example.com:test"
+            "existing_group",
+            "iscsi",
+            "iqn.2023-01.example.com:test",
         )
         mock_logger.debug.assert_any_call(
             "Group %s for %s/%s exists but config differs",
-            "update_group", "iscsi", "iqn.2023-01.example.com:test"
+            "update_group",
+            "iscsi",
+            "iqn.2023-01.example.com:test",
         )
-        mock_logger.debug.assert_any_call("Created group %s for %s/%s",
-                                          "update_group", "iscsi", "iqn.2023-01.example.com:test")
-        mock_logger.debug.assert_any_call("Created group %s for %s/%s",
-                                          "new_group", "iscsi", "iqn.2023-01.example.com:test")
+        mock_logger.debug.assert_any_call(
+            "Created group %s for %s/%s",
+            "update_group",
+            "iscsi",
+            "iqn.2023-01.example.com:test",
+        )
+        mock_logger.debug.assert_any_call(
+            "Created group %s for %s/%s",
+            "new_group",
+            "iscsi",
+            "iqn.2023-01.example.com:test",
+        )
 
-    def test_update_target_groups_comprehensive_workflow(self,
-                                                         target_writer,
-                                                         mock_sysfs,
-                                                         mock_config_reader,
-                                                         mock_logger):
+    def test_update_target_groups_comprehensive_workflow(
+        self, target_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test _update_target_groups with comprehensive group update workflow
 
@@ -1873,9 +2204,9 @@ class TestTargetWriter:
         target = "iqn.2023-01.example.com:test"
         target_config = Mock()
         target_config.groups = {
-            "match_group": Mock(),      # Exists with matching config, will be skipped
-            "update_group": Mock(),     # Exists but config differs, will be updated
-            "new_group": Mock()         # Doesn't exist, will be created
+            "match_group": Mock(),  # Exists with matching config, will be skipped
+            "update_group": Mock(),  # Exists but config differs, will be updated
+            "new_group": Mock(),  # Doesn't exist, will be created
         }
 
         # Configure Mock objects to have necessary attributes (to avoid iteration errors)
@@ -1886,13 +2217,18 @@ class TestTargetWriter:
 
         # Mock helper methods
         def mock_group_exists(driver, target, group_name):
-            return group_name in ["match_group", "update_group"]  # new_group doesn't exist
+            return group_name in [
+                "match_group",
+                "update_group",
+            ]  # new_group doesn't exist
 
         def mock_group_config_matches(driver, target, group_name, group_config):
             return group_name == "match_group"  # Only match_group matches
 
         target_writer._group_exists = Mock(side_effect=mock_group_exists)
-        target_writer._group_config_matches = Mock(side_effect=mock_group_config_matches)
+        target_writer._group_config_matches = Mock(
+            side_effect=mock_group_config_matches
+        )
         target_writer._update_group_config = Mock()
 
         # Configure successful sysfs writes
@@ -1905,17 +2241,21 @@ class TestTargetWriter:
         expected_exists_calls = [
             call(driver, target, "match_group"),
             call(driver, target, "update_group"),
-            call(driver, target, "new_group")
+            call(driver, target, "new_group"),
         ]
-        target_writer._group_exists.assert_has_calls(expected_exists_calls, any_order=True)
+        target_writer._group_exists.assert_has_calls(
+            expected_exists_calls, any_order=True
+        )
 
         # Assert: Verify config matching checks for existing groups
         expected_config_calls = [
             call(driver, target, "match_group", target_config.groups["match_group"]),
-            call(driver, target, "update_group", target_config.groups["update_group"])
+            call(driver, target, "update_group", target_config.groups["update_group"]),
             # new_group not checked because it doesn't exist
         ]
-        target_writer._group_config_matches.assert_has_calls(expected_config_calls, any_order=True)
+        target_writer._group_config_matches.assert_has_calls(
+            expected_config_calls, any_order=True
+        )
 
         # Assert: Verify group config update for differing group
         target_writer._update_group_config.assert_called_once_with(
@@ -1930,30 +2270,44 @@ class TestTargetWriter:
         expected_sysfs_calls = [
             call(mgmt_path, "create new_group"),
             call(initiators_mgmt_path, "add iqn.example:client1"),
-            call(luns_mgmt_path, "add disk1 0")
+            call(luns_mgmt_path, "add disk1 0"),
         ]
         mock_sysfs.write_sysfs.assert_has_calls(expected_sysfs_calls, any_order=True)
 
         # Assert: Verify debug logging
         expected_debug_calls = [
-            call("Group %s for %s/%s already exists with matching config, skipping",
-                 "match_group", "iscsi", "iqn.2023-01.example.com:test"),
-            call("Group %s for %s/%s config differs, updating incrementally",
-                 "update_group", "iscsi", "iqn.2023-01.example.com:test"),
-            call("Group %s for %s/%s doesn't exist, creating",
-                 "new_group", "iscsi", "iqn.2023-01.example.com:test"),
-            call("Created group %s for %s/%s",
-                 "new_group", "iscsi", "iqn.2023-01.example.com:test"),
+            call(
+                "Group %s for %s/%s already exists with matching config, skipping",
+                "match_group",
+                "iscsi",
+                "iqn.2023-01.example.com:test",
+            ),
+            call(
+                "Group %s for %s/%s config differs, updating incrementally",
+                "update_group",
+                "iscsi",
+                "iqn.2023-01.example.com:test",
+            ),
+            call(
+                "Group %s for %s/%s doesn't exist, creating",
+                "new_group",
+                "iscsi",
+                "iqn.2023-01.example.com:test",
+            ),
+            call(
+                "Created group %s for %s/%s",
+                "new_group",
+                "iscsi",
+                "iqn.2023-01.example.com:test",
+            ),
             call("Added initiator %s to group %s", "iqn.example:client1", "new_group"),
-            call("Added LUN %s (%s) to group %s", "0", "disk1", "new_group")
+            call("Added LUN %s (%s) to group %s", "0", "disk1", "new_group"),
         ]
         mock_logger.debug.assert_has_calls(expected_debug_calls, any_order=True)
 
-    def test_update_group_config_comprehensive_workflow(self,
-                                                        target_writer,
-                                                        mock_sysfs,
-                                                        mock_config_reader,
-                                                        mock_logger):
+    def test_update_group_config_comprehensive_workflow(
+        self, target_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test _update_group_config with comprehensive group configuration workflow
 
@@ -1972,9 +2326,9 @@ class TestTargetWriter:
         group_name = "storage_clients"
         group_config = Mock()
         group_config.initiators = [
-            "iqn.example:client1",         # Existing, keep
-            "iqn.example:client\\#3",      # New, add (with escaping)
-            "iqn.example:client4"          # New, add
+            "iqn.example:client1",  # Existing, keep
+            "iqn.example:client\\#3",  # New, add (with escaping)
+            "iqn.example:client4",  # New, add
             # client2 exists in sysfs but not in config, should be removed
         ]
 
@@ -1988,7 +2342,11 @@ class TestTargetWriter:
 
         def mock_listdir(path):
             if path == initiators_path:
-                return ["iqn.example:client1", "iqn.example:client2", "mgmt"]  # Current initiators
+                return [
+                    "iqn.example:client1",
+                    "iqn.example:client2",
+                    "mgmt",
+                ]  # Current initiators
             return []
 
         def mock_isfile(path):
@@ -2002,11 +2360,12 @@ class TestTargetWriter:
         # Configure successful mgmt operations
         mock_sysfs.mgmt_operation.return_value = None
 
-        with patch('os.path.exists', side_effect=mock_exists), \
-             patch('os.listdir', side_effect=mock_listdir), \
-             patch('os.path.isfile', side_effect=mock_isfile), \
-             patch('os.path.join', side_effect=lambda *args: '/'.join(args)):
-
+        with (
+            patch("os.path.exists", side_effect=mock_exists),
+            patch("os.listdir", side_effect=mock_listdir),
+            patch("os.path.isfile", side_effect=mock_isfile),
+            patch("os.path.join", side_effect=lambda *args: "/".join(args)),
+        ):
             # Act: Call the method under test
             target_writer._update_group_config(driver, target, group_name, group_config)
 
@@ -2017,22 +2376,36 @@ class TestTargetWriter:
 
         # Assert: Verify initiator additions (missing initiators)
         expected_add_calls = [
-            call(initiators_mgmt_path, "add", "iqn.example:client#3",  # Escaping removed: \\# -> #
-                 "Added initiator iqn.example:client#3 to group storage_clients",
-                 "Failed to add initiator iqn.example:client#3 to group storage_clients"),
-            call(initiators_mgmt_path, "add", "iqn.example:client4",
-                 "Added initiator iqn.example:client4 to group storage_clients",
-                 "Failed to add initiator iqn.example:client4 to group storage_clients")
+            call(
+                initiators_mgmt_path,
+                "add",
+                "iqn.example:client#3",  # Escaping removed: \\# -> #
+                "Added initiator iqn.example:client#3 to group storage_clients",
+                "Failed to add initiator iqn.example:client#3 to group storage_clients",
+            ),
+            call(
+                initiators_mgmt_path,
+                "add",
+                "iqn.example:client4",
+                "Added initiator iqn.example:client4 to group storage_clients",
+                "Failed to add initiator iqn.example:client4 to group storage_clients",
+            ),
         ]
         mock_sysfs.mgmt_operation.assert_has_calls(expected_add_calls, any_order=True)
 
         # Assert: Verify initiator removal (obsolete initiators)
         expected_remove_calls = [
-            call(initiators_mgmt_path, "del", "iqn.example:client2",  # client2 not in desired config
-                 "Removed initiator iqn.example:client2 from group storage_clients",
-                 "Failed to remove initiator iqn.example:client2 from group storage_clients")
+            call(
+                initiators_mgmt_path,
+                "del",
+                "iqn.example:client2",  # client2 not in desired config
+                "Removed initiator iqn.example:client2 from group storage_clients",
+                "Failed to remove initiator iqn.example:client2 from group storage_clients",
+            )
         ]
-        mock_sysfs.mgmt_operation.assert_has_calls(expected_remove_calls, any_order=True)
+        mock_sysfs.mgmt_operation.assert_has_calls(
+            expected_remove_calls, any_order=True
+        )
 
         # Assert: Verify LUN assignment update delegation
         target_writer._update_group_lun_assignments.assert_called_once_with(
@@ -2040,7 +2413,9 @@ class TestTargetWriter:
         )
 
         # Assert: Verify debug logging for method entry
-        mock_logger.debug.assert_any_call("Updating group %s configuration incrementally", "storage_clients")
+        mock_logger.debug.assert_any_call(
+            "Updating group %s configuration incrementally", "storage_clients"
+        )
 
 
 class TestGroupWriter:
@@ -2087,7 +2462,7 @@ class TestGroupWriter:
         group_name = "dg1"
 
         # Mock filesystem operation to return True (group exists)
-        with patch('os.path.exists', return_value=True) as mock_exists:
+        with patch("os.path.exists", return_value=True) as mock_exists:
             # Act: Call the method under test
             result = group_writer._device_group_exists(group_name)
 
@@ -2110,7 +2485,7 @@ class TestGroupWriter:
         group_name = "nonexistent_group"
 
         # Mock filesystem operation to return False (group doesn't exist)
-        with patch('os.path.exists', return_value=False) as mock_exists:
+        with patch("os.path.exists", return_value=False) as mock_exists:
             # Act: Call the method under test
             result = group_writer._device_group_exists(group_name)
 
@@ -2120,7 +2495,9 @@ class TestGroupWriter:
                 "/sys/kernel/scst_tgt/device_groups/nonexistent_group"
             )
 
-    def test_remove_device_group_complete_cleanup(self, group_writer, mock_sysfs, mock_logger):
+    def test_remove_device_group_complete_cleanup(
+        self, group_writer, mock_sysfs, mock_logger
+    ):
         """
         Test successful device group removal with complete cleanup sequence
 
@@ -2138,7 +2515,7 @@ class TestGroupWriter:
         mock_sysfs.valid_path.side_effect = lambda path: True  # All paths exist
         mock_sysfs.list_directory.side_effect = [
             ["tg1", "tg2", "mgmt"],  # Target groups with mgmt interface
-            ["disk1", "disk2", "mgmt"]  # Devices with mgmt interface
+            ["disk1", "disk2", "mgmt"],  # Devices with mgmt interface
         ]
         mock_sysfs.write_sysfs.return_value = None
 
@@ -2148,32 +2525,38 @@ class TestGroupWriter:
         # Assert: Verify sysfs path validations
         expected_valid_path_calls = [
             call("/sys/kernel/scst_tgt/device_groups/dg1/target_groups"),
-            call("/sys/kernel/scst_tgt/device_groups/dg1/devices")
+            call("/sys/kernel/scst_tgt/device_groups/dg1/devices"),
         ]
         mock_sysfs.valid_path.assert_has_calls(expected_valid_path_calls)
 
         # Assert: Verify directory listings
         expected_list_calls = [
             call("/sys/kernel/scst_tgt/device_groups/dg1/target_groups"),
-            call("/sys/kernel/scst_tgt/device_groups/dg1/devices")
+            call("/sys/kernel/scst_tgt/device_groups/dg1/devices"),
         ]
         mock_sysfs.list_directory.assert_has_calls(expected_list_calls)
 
         # Assert: Verify cleanup operations were performed in correct sequence
         expected_write_calls = [
             # Remove target groups
-            call("/sys/kernel/scst_tgt/device_groups/dg1/target_groups/mgmt", "del tg1"),
-            call("/sys/kernel/scst_tgt/device_groups/dg1/target_groups/mgmt", "del tg2"),
+            call(
+                "/sys/kernel/scst_tgt/device_groups/dg1/target_groups/mgmt", "del tg1"
+            ),
+            call(
+                "/sys/kernel/scst_tgt/device_groups/dg1/target_groups/mgmt", "del tg2"
+            ),
             # Remove devices
             call("/sys/kernel/scst_tgt/device_groups/dg1/devices/mgmt", "del disk1"),
             call("/sys/kernel/scst_tgt/device_groups/dg1/devices/mgmt", "del disk2"),
             # Remove device group itself
-            call("/sys/kernel/scst_tgt/device_groups/mgmt", "del dg1")
+            call("/sys/kernel/scst_tgt/device_groups/mgmt", "del dg1"),
         ]
         mock_sysfs.write_sysfs.assert_has_calls(expected_write_calls)
         assert mock_sysfs.write_sysfs.call_count == 5
 
-    def test_remove_device_group_minimal_group(self, group_writer, mock_sysfs, mock_logger):
+    def test_remove_device_group_minimal_group(
+        self, group_writer, mock_sysfs, mock_logger
+    ):
         """
         Test removal of minimal device group with no target groups or devices
 
@@ -2196,20 +2579,21 @@ class TestGroupWriter:
         # Assert: Verify path validation attempts
         expected_valid_path_calls = [
             call("/sys/kernel/scst_tgt/device_groups/empty_group/target_groups"),
-            call("/sys/kernel/scst_tgt/device_groups/empty_group/devices")
+            call("/sys/kernel/scst_tgt/device_groups/empty_group/devices"),
         ]
         mock_sysfs.valid_path.assert_has_calls(expected_valid_path_calls)
 
         # Assert: Verify only group removal was performed (no target group/device cleanup)
         mock_sysfs.write_sysfs.assert_called_once_with(
-            "/sys/kernel/scst_tgt/device_groups/mgmt",
-            "del empty_group"
+            "/sys/kernel/scst_tgt/device_groups/mgmt", "del empty_group"
         )
 
         # Assert: Verify no directory listing (paths don't exist)
         mock_sysfs.list_directory.assert_not_called()
 
-    def test_remove_device_group_partial_components(self, group_writer, mock_sysfs, mock_logger):
+    def test_remove_device_group_partial_components(
+        self, group_writer, mock_sysfs, mock_logger
+    ):
         """
         Test device group removal when only some components exist
 
@@ -2236,7 +2620,7 @@ class TestGroupWriter:
         # Assert: Verify both path validations were attempted
         expected_valid_path_calls = [
             call("/sys/kernel/scst_tgt/device_groups/partial_group/target_groups"),
-            call("/sys/kernel/scst_tgt/device_groups/partial_group/devices")
+            call("/sys/kernel/scst_tgt/device_groups/partial_group/devices"),
         ]
         mock_sysfs.valid_path.assert_has_calls(expected_valid_path_calls)
 
@@ -2248,14 +2632,19 @@ class TestGroupWriter:
         # Assert: Verify operations for existing components only
         expected_write_calls = [
             # Remove target group (devices section skipped)
-            call("/sys/kernel/scst_tgt/device_groups/partial_group/target_groups/mgmt", "del tg1"),
+            call(
+                "/sys/kernel/scst_tgt/device_groups/partial_group/target_groups/mgmt",
+                "del tg1",
+            ),
             # Remove device group itself
-            call("/sys/kernel/scst_tgt/device_groups/mgmt", "del partial_group")
+            call("/sys/kernel/scst_tgt/device_groups/mgmt", "del partial_group"),
         ]
         mock_sysfs.write_sysfs.assert_has_calls(expected_write_calls)
         assert mock_sysfs.write_sysfs.call_count == 2
 
-    def test_remove_device_group_sysfs_error_handling(self, group_writer, mock_sysfs, mock_logger):
+    def test_remove_device_group_sysfs_error_handling(
+        self, group_writer, mock_sysfs, mock_logger
+    ):
         """
         Test error handling when sysfs operations fail during group removal
 
@@ -2285,11 +2674,12 @@ class TestGroupWriter:
 
         # Assert: Verify removal was attempted
         mock_sysfs.write_sysfs.assert_called_once_with(
-            "/sys/kernel/scst_tgt/device_groups/mgmt",
-            "del error_group"
+            "/sys/kernel/scst_tgt/device_groups/mgmt", "del error_group"
         )
 
-    def test_remove_device_group_mgmt_interface_filtering(self, group_writer, mock_sysfs, mock_logger):
+    def test_remove_device_group_mgmt_interface_filtering(
+        self, group_writer, mock_sysfs, mock_logger
+    ):
         """
         Test that management interface entries are properly filtered out
 
@@ -2306,7 +2696,7 @@ class TestGroupWriter:
         mock_sysfs.valid_path.side_effect = lambda path: True
         mock_sysfs.list_directory.side_effect = [
             ["mgmt", "tg1", "mgmt", "tg2"],  # Target groups with multiple mgmt entries
-            ["disk1", "mgmt", "disk2", "mgmt"]  # Devices with multiple mgmt entries
+            ["disk1", "mgmt", "disk2", "mgmt"],  # Devices with multiple mgmt entries
         ]
         mock_sysfs.write_sysfs.return_value = None
 
@@ -2316,16 +2706,30 @@ class TestGroupWriter:
         # Assert: Verify mgmt interfaces were filtered out
         # Should only have operations for tg1, tg2, disk1, disk2 + final group removal
         expected_write_calls = [
-            call("/sys/kernel/scst_tgt/device_groups/mgmt_test_group/target_groups/mgmt", "del tg1"),
-            call("/sys/kernel/scst_tgt/device_groups/mgmt_test_group/target_groups/mgmt", "del tg2"),
-            call("/sys/kernel/scst_tgt/device_groups/mgmt_test_group/devices/mgmt", "del disk1"),
-            call("/sys/kernel/scst_tgt/device_groups/mgmt_test_group/devices/mgmt", "del disk2"),
-            call("/sys/kernel/scst_tgt/device_groups/mgmt", "del mgmt_test_group")
+            call(
+                "/sys/kernel/scst_tgt/device_groups/mgmt_test_group/target_groups/mgmt",
+                "del tg1",
+            ),
+            call(
+                "/sys/kernel/scst_tgt/device_groups/mgmt_test_group/target_groups/mgmt",
+                "del tg2",
+            ),
+            call(
+                "/sys/kernel/scst_tgt/device_groups/mgmt_test_group/devices/mgmt",
+                "del disk1",
+            ),
+            call(
+                "/sys/kernel/scst_tgt/device_groups/mgmt_test_group/devices/mgmt",
+                "del disk2",
+            ),
+            call("/sys/kernel/scst_tgt/device_groups/mgmt", "del mgmt_test_group"),
         ]
         mock_sysfs.write_sysfs.assert_has_calls(expected_write_calls)
         assert mock_sysfs.write_sysfs.call_count == 5
 
-    def test_update_device_group_devices_add_and_remove(self, group_writer, mock_sysfs, mock_logger):
+    def test_update_device_group_devices_add_and_remove(
+        self, group_writer, mock_sysfs, mock_logger
+    ):
         """
         Test device group device membership updates with additions and removals
 
@@ -2347,13 +2751,17 @@ class TestGroupWriter:
         devices_path = "/sys/kernel/scst_tgt/device_groups/dg1/devices"
 
         # Mock os.path.exists and os.listdir for reading current devices
-        with patch('os.path.exists', return_value=True) as mock_exists, \
-             patch('os.listdir', return_value=["disk1", "disk2", "mgmt"]) as mock_listdir, \
-             patch('os.path.islink') as mock_islink:
-
+        with (
+            patch("os.path.exists", return_value=True) as mock_exists,
+            patch(
+                "os.listdir", return_value=["disk1", "disk2", "mgmt"]
+            ) as mock_listdir,
+            patch("os.path.islink") as mock_islink,
+        ):
             # Configure islink to return True for actual devices, False for mgmt
             def mock_islink_side_effect(path):
                 return "disk1" in path or "disk2" in path  # disk1, disk2 are symlinks
+
             mock_islink.side_effect = mock_islink_side_effect
 
             # Configure successful sysfs writes
@@ -2369,24 +2777,32 @@ class TestGroupWriter:
             # Assert: Verify islink checks for actual items (excluding mgmt)
             expected_islink_calls = [
                 call("/sys/kernel/scst_tgt/device_groups/dg1/devices/disk1"),
-                call("/sys/kernel/scst_tgt/device_groups/dg1/devices/disk2")
+                call("/sys/kernel/scst_tgt/device_groups/dg1/devices/disk2"),
             ]
             mock_islink.assert_has_calls(expected_islink_calls, any_order=True)
 
             # Assert: Verify device management operations
             expected_write_calls = [
                 # Remove disk2 (current but not desired)
-                call("/sys/kernel/scst_tgt/device_groups/dg1/devices/mgmt", "del disk2"),
+                call(
+                    "/sys/kernel/scst_tgt/device_groups/dg1/devices/mgmt", "del disk2"
+                ),
                 # Add disk3 (desired but not current)
-                call("/sys/kernel/scst_tgt/device_groups/dg1/devices/mgmt", "add disk3")
+                call(
+                    "/sys/kernel/scst_tgt/device_groups/dg1/devices/mgmt", "add disk3"
+                ),
             ]
-            mock_sysfs.write_sysfs.assert_has_calls(expected_write_calls, any_order=True)
+            mock_sysfs.write_sysfs.assert_has_calls(
+                expected_write_calls, any_order=True
+            )
             assert mock_sysfs.write_sysfs.call_count == 2
 
             # Assert: Verify debug logging
             assert mock_logger.debug.call_count >= 3  # Operation logs + summary
 
-    def test_update_device_group_devices_no_changes_needed(self, group_writer, mock_sysfs, mock_logger):
+    def test_update_device_group_devices_no_changes_needed(
+        self, group_writer, mock_sysfs, mock_logger
+    ):
         """
         Test device group update when no changes are needed
 
@@ -2403,10 +2819,11 @@ class TestGroupWriter:
         mock_group_config.devices = {"disk1": {}, "disk2": {}}  # Want disk1, disk2
 
         # Mock os operations to show current devices match desired
-        with patch('os.path.exists', return_value=True), \
-             patch('os.listdir', return_value=["disk1", "disk2", "mgmt"]), \
-             patch('os.path.islink', return_value=True):  # All devices are symlinks
-
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.listdir", return_value=["disk1", "disk2", "mgmt"]),
+            patch("os.path.islink", return_value=True),
+        ):  # All devices are symlinks
             # Act: Call the method under test
             group_writer._update_device_group_devices(group_name, mock_group_config)
 
@@ -2414,9 +2831,13 @@ class TestGroupWriter:
             mock_sysfs.write_sysfs.assert_not_called()
 
             # Assert: Verify debug log about no changes needed
-            mock_logger.debug.assert_called_with("Device group %s membership already correct", "dg1")
+            mock_logger.debug.assert_called_with(
+                "Device group %s membership already correct", "dg1"
+            )
 
-    def test_set_target_group_target_attributes_success(self, group_writer, mock_sysfs, mock_logger):
+    def test_set_target_group_target_attributes_success(
+        self, group_writer, mock_sysfs, mock_logger
+    ):
         """
         Test successful setting of target group target attributes
 
@@ -2435,13 +2856,15 @@ class TestGroupWriter:
         target_path = "/sys/kernel/scst_tgt/device_groups/dg1/target_groups/controller_A/iqn.2023-01.example.com:test"
 
         # Mock target path as directory and attribute operations
-        with patch('os.path.isdir', return_value=True) as mock_isdir, \
-             patch('os.path.exists') as mock_exists:
-
+        with (
+            patch("os.path.isdir", return_value=True) as mock_isdir,
+            patch("os.path.exists") as mock_exists,
+        ):
             # Configure attribute existence and current values
             def mock_exists_side_effect(path):
                 # rel_tgt_id exists with different value, preferred doesn't exist
                 return path.endswith("/rel_tgt_id")
+
             mock_exists.side_effect = mock_exists_side_effect
 
             # Configure current attribute value check
@@ -2450,7 +2873,8 @@ class TestGroupWriter:
 
             # Act: Call the method under test
             group_writer._set_target_group_target_attributes(
-                device_group, tgroup_name, target_name, target_config)
+                device_group, tgroup_name, target_name, target_config
+            )
 
             # Assert: Verify directory check
             mock_isdir.assert_called_once_with(target_path)
@@ -2458,22 +2882,28 @@ class TestGroupWriter:
             # Assert: Verify attribute file existence checks
             expected_exists_calls = [
                 call(f"{target_path}/rel_tgt_id"),
-                call(f"{target_path}/preferred")
+                call(f"{target_path}/preferred"),
             ]
             mock_exists.assert_has_calls(expected_exists_calls, any_order=True)
 
             # Assert: Verify current value read for existing attribute
-            mock_sysfs.read_sysfs_attribute.assert_called_once_with(f"{target_path}/rel_tgt_id")
+            mock_sysfs.read_sysfs_attribute.assert_called_once_with(
+                f"{target_path}/rel_tgt_id"
+            )
 
             # Assert: Verify attribute writes
             expected_write_calls = [
                 call(f"{target_path}/rel_tgt_id", "1", check_result=False),
-                call(f"{target_path}/preferred", "1", check_result=False)
+                call(f"{target_path}/preferred", "1", check_result=False),
             ]
-            mock_sysfs.write_sysfs.assert_has_calls(expected_write_calls, any_order=True)
+            mock_sysfs.write_sysfs.assert_has_calls(
+                expected_write_calls, any_order=True
+            )
             assert mock_sysfs.write_sysfs.call_count == 2
 
-    def test_set_target_group_target_attributes_symlink_skip(self, group_writer, mock_sysfs, mock_logger):
+    def test_set_target_group_target_attributes_symlink_skip(
+        self, group_writer, mock_sysfs, mock_logger
+    ):
         """
         Test that symlink targets are skipped with appropriate logging
 
@@ -2489,11 +2919,11 @@ class TestGroupWriter:
         target_config = {"rel_tgt_id": "1"}
 
         # Mock target path as NOT a directory (symlink)
-        with patch('os.path.isdir', return_value=False) as mock_isdir:
-
+        with patch("os.path.isdir", return_value=False) as mock_isdir:
             # Act: Call the method under test
             group_writer._set_target_group_target_attributes(
-                device_group, tgroup_name, target_name, target_config)
+                device_group, tgroup_name, target_name, target_config
+            )
 
             # Assert: Verify directory check was performed
             mock_isdir.assert_called_once()
@@ -2501,14 +2931,16 @@ class TestGroupWriter:
             # Assert: Verify debug log about symlink
             mock_logger.debug.assert_called_once_with(
                 "Target %s is symlink, cannot set attributes - SCST will handle this automatically",
-                "iqn.2023-01.example.com:test"
+                "iqn.2023-01.example.com:test",
             )
 
             # Assert: Verify no sysfs operations
             mock_sysfs.write_sysfs.assert_not_called()
             mock_sysfs.read_sysfs_attribute.assert_not_called()
 
-    def test_device_group_config_matches_true(self, group_writer, mock_sysfs, mock_config_reader):
+    def test_device_group_config_matches_true(
+        self, group_writer, mock_sysfs, mock_config_reader
+    ):
         """
         Test _device_group_config_matches when configuration matches current state
 
@@ -2523,23 +2955,24 @@ class TestGroupWriter:
         group_name = "storage_group"
         group_config = Mock()
         group_config.devices = {"disk1", "disk2"}
-        group_config.target_groups = {
-            "controller_A": Mock(),
-            "controller_B": Mock()
-        }
+        group_config.target_groups = {"controller_A": Mock(), "controller_B": Mock()}
 
         # Mock filesystem structure that matches the configuration
         def mock_exists(path):
             return path in [
                 "/sys/kernel/scst_tgt/device_groups/storage_group/devices",
-                "/sys/kernel/scst_tgt/device_groups/storage_group/target_groups"
+                "/sys/kernel/scst_tgt/device_groups/storage_group/target_groups",
             ]
 
         def mock_listdir(path):
             if "devices" in path:
                 return ["disk1", "disk2", "mgmt"]  # mgmt will be filtered out
             elif "target_groups" in path:
-                return ["controller_A", "controller_B", "mgmt"]  # mgmt will be filtered out
+                return [
+                    "controller_A",
+                    "controller_B",
+                    "mgmt",
+                ]  # mgmt will be filtered out
             return []
 
         def mock_isdir(path):
@@ -2549,10 +2982,11 @@ class TestGroupWriter:
         # Mock target group config matches to return True for both groups
         group_writer._target_group_config_matches = Mock(return_value=True)
 
-        with patch('os.path.exists', side_effect=mock_exists), \
-             patch('os.listdir', side_effect=mock_listdir), \
-             patch('os.path.isdir', side_effect=mock_isdir):
-
+        with (
+            patch("os.path.exists", side_effect=mock_exists),
+            patch("os.listdir", side_effect=mock_listdir),
+            patch("os.path.isdir", side_effect=mock_isdir),
+        ):
             # Act: Call the method under test
             result = group_writer._device_group_config_matches(group_name, group_config)
 
@@ -2561,12 +2995,22 @@ class TestGroupWriter:
 
         # Assert: Verify target group config checking was called for each target group
         expected_calls = [
-            call("storage_group", "controller_A", group_config.target_groups["controller_A"]),
-            call("storage_group", "controller_B", group_config.target_groups["controller_B"])
+            call(
+                "storage_group",
+                "controller_A",
+                group_config.target_groups["controller_A"],
+            ),
+            call(
+                "storage_group",
+                "controller_B",
+                group_config.target_groups["controller_B"],
+            ),
         ]
         group_writer._target_group_config_matches.assert_has_calls(expected_calls)
 
-    def test_target_group_config_matches_true(self, group_writer, mock_sysfs, mock_config_reader):
+    def test_target_group_config_matches_true(
+        self, group_writer, mock_sysfs, mock_config_reader
+    ):
         """
         Test _target_group_config_matches when ALUA target group configuration matches
 
@@ -2598,7 +3042,7 @@ class TestGroupWriter:
                 targets_path,
                 f"{targets_path}/group_id",
                 f"{targets_path}/state",
-                f"{targets_path}/iqn.example:test1/rel_tgt_id"
+                f"{targets_path}/iqn.example:test1/rel_tgt_id",
             ]
 
         def mock_listdir(path):
@@ -2611,7 +3055,9 @@ class TestGroupWriter:
             # - test1 is actual directory (has attributes)
             # - test2 is symlink to directory (no attributes but still valid)
             # Only mgmt should return False
-            return (path.endswith("/iqn.example:test1") or path.endswith("/iqn.example:test2"))
+            return path.endswith("/iqn.example:test1") or path.endswith(
+                "/iqn.example:test2"
+            )
 
         # Mock sysfs attribute reads
         def mock_read_sysfs_attribute(path):
@@ -2625,12 +3071,15 @@ class TestGroupWriter:
 
         mock_sysfs.read_sysfs_attribute.side_effect = mock_read_sysfs_attribute
 
-        with patch('os.path.exists', side_effect=mock_exists), \
-             patch('os.listdir', side_effect=mock_listdir), \
-             patch('os.path.isdir', side_effect=mock_isdir):
-
+        with (
+            patch("os.path.exists", side_effect=mock_exists),
+            patch("os.listdir", side_effect=mock_listdir),
+            patch("os.path.isdir", side_effect=mock_isdir),
+        ):
             # Act: Call the method under test
-            result = group_writer._target_group_config_matches(device_group, target_group, tgroup_config)
+            result = group_writer._target_group_config_matches(
+                device_group, target_group, tgroup_config
+            )
 
         # Assert: Verify method returns True for matching configuration
         assert result is True
@@ -2639,11 +3088,15 @@ class TestGroupWriter:
         expected_read_calls = [
             call(f"{targets_path}/group_id"),
             call(f"{targets_path}/state"),
-            call(f"{targets_path}/iqn.example:test1/rel_tgt_id")
+            call(f"{targets_path}/iqn.example:test1/rel_tgt_id"),
         ]
-        mock_sysfs.read_sysfs_attribute.assert_has_calls(expected_read_calls, any_order=True)
+        mock_sysfs.read_sysfs_attribute.assert_has_calls(
+            expected_read_calls, any_order=True
+        )
 
-    def test_update_device_group_incremental_updates(self, group_writer, mock_sysfs, mock_config_reader, mock_logger):
+    def test_update_device_group_incremental_updates(
+        self, group_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test _update_device_group performs incremental updates correctly
 
@@ -2657,10 +3110,7 @@ class TestGroupWriter:
         # Arrange: Set up test data
         group_name = "storage_group"
         group_config = Mock()
-        group_config.attributes = {
-            "some_attr": "value1",
-            "another_attr": "value2"
-        }
+        group_config.attributes = {"some_attr": "value1", "another_attr": "value2"}
 
         # Mock the delegated methods
         group_writer._update_device_group_devices = Mock()
@@ -2673,35 +3123,51 @@ class TestGroupWriter:
         group_writer._update_device_group(group_name, group_config)
 
         # Assert: Verify delegation to device update method
-        group_writer._update_device_group_devices.assert_called_once_with(group_name, group_config)
+        group_writer._update_device_group_devices.assert_called_once_with(
+            group_name, group_config
+        )
 
         # Assert: Verify delegation to target group update method
         group_writer._update_device_group_target_groups.assert_called_once_with(
-            group_name, group_config)
+            group_name, group_config
+        )
 
         # Assert: Verify group attribute updates
         expected_write_calls = [
-            call("/sys/kernel/scst_tgt/device_groups/storage_group/some_attr",
-                 "value1", check_result=False),
-            call("/sys/kernel/scst_tgt/device_groups/storage_group/another_attr",
-                 "value2", check_result=False)
+            call(
+                "/sys/kernel/scst_tgt/device_groups/storage_group/some_attr",
+                "value1",
+                check_result=False,
+            ),
+            call(
+                "/sys/kernel/scst_tgt/device_groups/storage_group/another_attr",
+                "value2",
+                check_result=False,
+            ),
         ]
         mock_sysfs.write_sysfs.assert_has_calls(expected_write_calls, any_order=True)
         assert mock_sysfs.write_sysfs.call_count == 2
 
         # Assert: Verify debug logging
-        mock_logger.debug.assert_any_call("Updating device group %s configuration incrementally",
-                                          "storage_group")
-        mock_logger.debug.assert_any_call("Updated device group attribute %s.%s = %s",
-                                          "storage_group", "some_attr", "value1")
-        mock_logger.debug.assert_any_call("Updated device group attribute %s.%s = %s",
-                                          "storage_group", "another_attr", "value2")
+        mock_logger.debug.assert_any_call(
+            "Updating device group %s configuration incrementally", "storage_group"
+        )
+        mock_logger.debug.assert_any_call(
+            "Updated device group attribute %s.%s = %s",
+            "storage_group",
+            "some_attr",
+            "value1",
+        )
+        mock_logger.debug.assert_any_call(
+            "Updated device group attribute %s.%s = %s",
+            "storage_group",
+            "another_attr",
+            "value2",
+        )
 
-    def test_update_device_group_target_groups_synchronization(self,
-                                                               group_writer,
-                                                               mock_sysfs,
-                                                               mock_config_reader,
-                                                               mock_logger):
+    def test_update_device_group_target_groups_synchronization(
+        self, group_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test _update_device_group_target_groups synchronizes target groups correctly
 
@@ -2718,11 +3184,13 @@ class TestGroupWriter:
         group_config = Mock()
         group_config.target_groups = {
             "controller_A": Mock(),  # Existing, needs update
-            "controller_C": Mock()   # New, needs creation
+            "controller_C": Mock(),  # New, needs creation
             # controller_B exists but not in config, needs removal
         }
 
-        target_groups_path = "/sys/kernel/scst_tgt/device_groups/storage_group/target_groups"
+        target_groups_path = (
+            "/sys/kernel/scst_tgt/device_groups/storage_group/target_groups"
+        )
 
         # Mock filesystem operations showing current state
         def mock_exists(path):
@@ -2744,10 +3212,11 @@ class TestGroupWriter:
         # Configure successful sysfs writes
         mock_sysfs.write_sysfs.return_value = None
 
-        with patch('os.path.exists', side_effect=mock_exists), \
-             patch('os.listdir', side_effect=mock_listdir), \
-             patch('os.path.isdir', side_effect=mock_isdir):
-
+        with (
+            patch("os.path.exists", side_effect=mock_exists),
+            patch("os.listdir", side_effect=mock_listdir),
+            patch("os.path.isdir", side_effect=mock_isdir),
+        ):
             # Act: Call the method under test
             group_writer._update_device_group_target_groups(group_name, group_config)
 
@@ -2767,20 +3236,28 @@ class TestGroupWriter:
         )
 
         # Assert: Verify debug logging
-        mock_logger.debug.assert_any_call("Updating target groups for device group %s",
-                                          "storage_group")
-        mock_logger.debug.assert_any_call("Removed target group %s from device group %s",
-                                          "controller_B", "storage_group")
-        mock_logger.debug.assert_any_call("Creating target group %s in device group %s",
-                                          "controller_C", "storage_group")
-        mock_logger.debug.assert_any_call("Updating target group %s in device group %s",
-                                          "controller_A", "storage_group")
+        mock_logger.debug.assert_any_call(
+            "Updating target groups for device group %s", "storage_group"
+        )
+        mock_logger.debug.assert_any_call(
+            "Removed target group %s from device group %s",
+            "controller_B",
+            "storage_group",
+        )
+        mock_logger.debug.assert_any_call(
+            "Creating target group %s in device group %s",
+            "controller_C",
+            "storage_group",
+        )
+        mock_logger.debug.assert_any_call(
+            "Updating target group %s in device group %s",
+            "controller_A",
+            "storage_group",
+        )
 
-    def test_update_target_group_attributes_with_value_checking(self,
-                                                                group_writer,
-                                                                mock_sysfs,
-                                                                mock_config_reader,
-                                                                mock_logger):
+    def test_update_target_group_attributes_with_value_checking(
+        self, group_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test _update_target_group_attributes updates attributes with current value checking
 
@@ -2797,9 +3274,9 @@ class TestGroupWriter:
         tgroup_name = "controller_A"
         tgroup_config = Mock()
         tgroup_config.attributes = {
-            "group_id": "101",   # Current value is "100", needs update
-            "state": "active",   # Current value is "active", no update needed
-            "new_attr": "value"  # Attribute doesn't exist, needs creation
+            "group_id": "101",  # Current value is "100", needs update
+            "state": "active",  # Current value is "active", no update needed
+            "new_attr": "value",  # Attribute doesn't exist, needs creation
         }
 
         base_path = "/sys/kernel/scst_tgt/device_groups/storage_group/target_groups/controller_A"
@@ -2823,10 +3300,11 @@ class TestGroupWriter:
         mock_sysfs.read_sysfs_attribute.side_effect = mock_read_sysfs_attribute
         mock_sysfs.write_sysfs.return_value = None
 
-        with patch('os.path.exists', side_effect=mock_exists):
-
+        with patch("os.path.exists", side_effect=mock_exists):
             # Act: Call the method under test
-            group_writer._update_target_group_attributes(device_group, tgroup_name, tgroup_config)
+            group_writer._update_target_group_attributes(
+                device_group, tgroup_name, tgroup_config
+            )
 
         # Assert: Verify target assignments updated first
         group_writer._update_target_group_targets.assert_called_once_with(
@@ -2836,14 +3314,16 @@ class TestGroupWriter:
         # Assert: Verify attribute reads for existing attributes
         expected_read_calls = [
             call(f"{base_path}/group_id"),
-            call(f"{base_path}/state")
+            call(f"{base_path}/state"),
         ]
-        mock_sysfs.read_sysfs_attribute.assert_has_calls(expected_read_calls, any_order=True)
+        mock_sysfs.read_sysfs_attribute.assert_has_calls(
+            expected_read_calls, any_order=True
+        )
 
         # Assert: Verify only changed/new attributes are written
         expected_write_calls = [
             call(f"{base_path}/group_id", "101", check_result=False),  # Changed value
-            call(f"{base_path}/new_attr", "value", check_result=False)  # New attribute
+            call(f"{base_path}/new_attr", "value", check_result=False),  # New attribute
             # state is NOT written because current value matches desired
         ]
         mock_sysfs.write_sysfs.assert_has_calls(expected_write_calls, any_order=True)
@@ -2852,22 +3332,30 @@ class TestGroupWriter:
         # Assert: Verify debug logging for value comparisons
         mock_logger.debug.assert_any_call(
             "Updated target group attribute %s.%s.%s: %s -> %s",
-            "storage_group", "controller_A", "group_id", "100", "101"
+            "storage_group",
+            "controller_A",
+            "group_id",
+            "100",
+            "101",
         )
         mock_logger.debug.assert_any_call(
             "Target group attribute %s.%s.%s already has correct value: %s",
-            "storage_group", "controller_A", "state", "active"
+            "storage_group",
+            "controller_A",
+            "state",
+            "active",
         )
         mock_logger.debug.assert_any_call(
             "Set target group attribute %s.%s.%s = %s",
-            "storage_group", "controller_A", "new_attr", "value"
+            "storage_group",
+            "controller_A",
+            "new_attr",
+            "value",
         )
 
-    def test_update_target_group_targets_with_alua_attributes(self,
-                                                              group_writer,
-                                                              mock_sysfs,
-                                                              mock_config_reader,
-                                                              mock_logger):
+    def test_update_target_group_targets_with_alua_attributes(
+        self, group_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test _update_target_group_targets manages target membership and ALUA attributes
 
@@ -2883,10 +3371,13 @@ class TestGroupWriter:
         device_group = "storage_group"
         tgroup_name = "controller_A"
         tgroup_config = Mock()
-        tgroup_config.targets = {"iqn.example:test1", "iqn.example:test3"}  # want test1, test3
+        tgroup_config.targets = {
+            "iqn.example:test1",
+            "iqn.example:test3",
+        }  # want test1, test3
         tgroup_config.target_attributes = {
             "iqn.example:test1": {"rel_tgt_id": "1"},
-            "iqn.example:test3": {"rel_tgt_id": "3"}
+            "iqn.example:test3": {"rel_tgt_id": "3"},
         }
 
         tgroup_path = "/sys/kernel/scst_tgt/device_groups/storage_group/target_groups/controller_A"
@@ -2897,7 +3388,11 @@ class TestGroupWriter:
 
         def mock_listdir(path):
             if path == tgroup_path:
-                return ["iqn.example:test1", "iqn.example:test2", "mgmt"]  # current: test1, test2
+                return [
+                    "iqn.example:test1",
+                    "iqn.example:test2",
+                    "mgmt",
+                ]  # current: test1, test2
             return []
 
         # Mock sysfs helper methods
@@ -2912,29 +3407,42 @@ class TestGroupWriter:
         mock_sysfs.is_valid_sysfs_directory.side_effect = mock_is_valid_sysfs_directory
         mock_sysfs.mgmt_operation.return_value = None
 
-        with patch('os.path.exists', side_effect=mock_exists), \
-             patch('os.listdir', side_effect=mock_listdir):
-
+        with (
+            patch("os.path.exists", side_effect=mock_exists),
+            patch("os.listdir", side_effect=mock_listdir),
+        ):
             # Act: Call the method under test
-            group_writer._update_target_group_targets(device_group, tgroup_name, tgroup_config)
+            group_writer._update_target_group_targets(
+                device_group, tgroup_name, tgroup_config
+            )
 
         # Assert: Verify sysfs directory validation calls
         expected_is_valid_calls = [
             call(tgroup_path, "iqn.example:test1"),
-            call(tgroup_path, "iqn.example:test2")
+            call(tgroup_path, "iqn.example:test2"),
         ]
-        mock_sysfs.is_valid_sysfs_directory.assert_has_calls(expected_is_valid_calls, any_order=True)
+        mock_sysfs.is_valid_sysfs_directory.assert_has_calls(
+            expected_is_valid_calls, any_order=True
+        )
 
         # Assert: Verify mgmt operations for target membership changes
         expected_mgmt_calls = [
             # Add missing target (test3)
-            call(f"{tgroup_path}/mgmt", "add", "iqn.example:test3",
-                 "Added target iqn.example:test3 to target group storage_group/controller_A",
-                 "Failed to add target iqn.example:test3 to target group controller_A"),
+            call(
+                f"{tgroup_path}/mgmt",
+                "add",
+                "iqn.example:test3",
+                "Added target iqn.example:test3 to target group storage_group/controller_A",
+                "Failed to add target iqn.example:test3 to target group controller_A",
+            ),
             # Remove extra target (test2)
-            call(f"{tgroup_path}/mgmt", "del", "iqn.example:test2",
-                 "Removed target iqn.example:test2 from target group storage_group/controller_A",
-                 "Failed to remove target iqn.example:test2 from target group controller_A")
+            call(
+                f"{tgroup_path}/mgmt",
+                "del",
+                "iqn.example:test2",
+                "Removed target iqn.example:test2 from target group storage_group/controller_A",
+                "Failed to remove target iqn.example:test2 from target group controller_A",
+            ),
         ]
         mock_sysfs.mgmt_operation.assert_has_calls(expected_mgmt_calls, any_order=True)
         assert mock_sysfs.mgmt_operation.call_count == 2
@@ -2942,15 +3450,15 @@ class TestGroupWriter:
         # Assert: Verify target attributes are set for all configured targets
         expected_attr_calls = [
             call(device_group, tgroup_name, "iqn.example:test1", {"rel_tgt_id": "1"}),
-            call(device_group, tgroup_name, "iqn.example:test3", {"rel_tgt_id": "3"})
+            call(device_group, tgroup_name, "iqn.example:test3", {"rel_tgt_id": "3"}),
         ]
-        group_writer._set_target_group_target_attributes.assert_has_calls(expected_attr_calls, any_order=True)
+        group_writer._set_target_group_target_attributes.assert_has_calls(
+            expected_attr_calls, any_order=True
+        )
 
-    def test_create_target_group_full_alua_configuration(self,
-                                                         group_writer,
-                                                         mock_sysfs,
-                                                         mock_config_reader,
-                                                         mock_logger):
+    def test_create_target_group_full_alua_configuration(
+        self, group_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test _create_target_group creates target group with complete ALUA configuration
 
@@ -2973,7 +3481,9 @@ class TestGroupWriter:
         }
         tgroup_config.attributes = {"group_id": "101", "state": "active"}
 
-        tgroup_mgmt = "/sys/kernel/scst_tgt/device_groups/storage_group/target_groups/mgmt"
+        tgroup_mgmt = (
+            "/sys/kernel/scst_tgt/device_groups/storage_group/target_groups/mgmt"
+        )
         target_mgmt = "/sys/kernel/scst_tgt/device_groups/storage_group/target_groups/controller_A/mgmt"
 
         # Mock helper methods
@@ -2992,7 +3502,7 @@ class TestGroupWriter:
         # Assert: Verify all targets are added to target group
         expected_target_adds = [
             call(target_mgmt, "add iqn.example:test1"),
-            call(target_mgmt, "add iqn.example:test2")
+            call(target_mgmt, "add iqn.example:test2"),
         ]
         mock_sysfs.write_sysfs.assert_has_calls(expected_target_adds, any_order=True)
 
@@ -3008,7 +3518,9 @@ class TestGroupWriter:
 
         # Assert: Verify debug logging
         mock_logger.debug.assert_any_call(
-            "Created target group %s in device group %s", "controller_A", "storage_group"
+            "Created target group %s in device group %s",
+            "controller_A",
+            "storage_group",
         )
         mock_logger.debug.assert_any_call(
             "Added target %s to target group %s", "iqn.example:test1", "controller_A"
@@ -3017,11 +3529,9 @@ class TestGroupWriter:
             "Added target %s to target group %s", "iqn.example:test2", "controller_A"
         )
 
-    def test_apply_target_groups_create_and_update_logic(self,
-                                                         group_writer,
-                                                         mock_sysfs,
-                                                         mock_config_reader,
-                                                         mock_logger):
+    def test_apply_target_groups_create_and_update_logic(
+        self, group_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test _apply_target_groups applies target group configurations with create/update logic
 
@@ -3036,7 +3546,7 @@ class TestGroupWriter:
         device_group = "storage_group"
         target_groups = {
             "controller_A": Mock(),  # Exists, will be updated
-            "controller_C": Mock()   # Doesn't exist, will be created
+            "controller_C": Mock(),  # Doesn't exist, will be created
         }
 
         # Mock filesystem operations
@@ -3049,17 +3559,20 @@ class TestGroupWriter:
         group_writer._update_target_group_attributes = Mock()
         group_writer._create_target_group = Mock()
 
-        with patch('os.path.exists', side_effect=mock_exists):
-
+        with patch("os.path.exists", side_effect=mock_exists):
             # Act: Call the method under test
             group_writer._apply_target_groups(device_group, target_groups)
 
         # Assert: Verify existence checks for all target groups
         expected_exists_calls = [
-            call("/sys/kernel/scst_tgt/device_groups/storage_group/target_groups/controller_A"),
-            call("/sys/kernel/scst_tgt/device_groups/storage_group/target_groups/controller_C")
+            call(
+                "/sys/kernel/scst_tgt/device_groups/storage_group/target_groups/controller_A"
+            ),
+            call(
+                "/sys/kernel/scst_tgt/device_groups/storage_group/target_groups/controller_C"
+            ),
         ]
-        with patch('os.path.exists', side_effect=mock_exists) as mock_exists_patch:
+        with patch("os.path.exists", side_effect=mock_exists) as mock_exists_patch:
             # Re-run to capture the calls
             group_writer._apply_target_groups(device_group, target_groups)
             mock_exists_patch.assert_has_calls(expected_exists_calls, any_order=True)
@@ -3078,19 +3591,26 @@ class TestGroupWriter:
         )
 
         # Assert: Verify debug logging
-        mock_logger.debug.assert_any_call("Processing target group '%s' in device group '%s'",
-                                          "controller_A", "storage_group")
-        mock_logger.debug.assert_any_call("Target group %s exists, updating configuration",
-                                          "controller_A")
-        mock_logger.debug.assert_any_call("Processing target group '%s' in device group '%s'",
-                                          "controller_C", "storage_group")
-        mock_logger.debug.assert_any_call("Target group %s doesn't exist, creating", "controller_C")
+        mock_logger.debug.assert_any_call(
+            "Processing target group '%s' in device group '%s'",
+            "controller_A",
+            "storage_group",
+        )
+        mock_logger.debug.assert_any_call(
+            "Target group %s exists, updating configuration", "controller_A"
+        )
+        mock_logger.debug.assert_any_call(
+            "Processing target group '%s' in device group '%s'",
+            "controller_C",
+            "storage_group",
+        )
+        mock_logger.debug.assert_any_call(
+            "Target group %s doesn't exist, creating", "controller_C"
+        )
 
-    def test_apply_config_device_groups_comprehensive_workflow(self,
-                                                               group_writer,
-                                                               mock_sysfs,
-                                                               mock_config_reader,
-                                                               mock_logger):
+    def test_apply_config_device_groups_comprehensive_workflow(
+        self, group_writer, mock_sysfs, mock_config_reader, mock_logger
+    ):
         """
         Test apply_config_device_groups main entry point with comprehensive workflow
 
@@ -3107,7 +3627,7 @@ class TestGroupWriter:
         config = Mock()
         config.device_groups = {
             "existing_group": Mock(),  # Exists but config differs, will be updated
-            "new_group": Mock()        # Doesn't exist, will be created
+            "new_group": Mock(),  # Doesn't exist, will be created
         }
 
         # Configure existing group
@@ -3123,8 +3643,12 @@ class TestGroupWriter:
         new_group.target_groups = {"controller_B": Mock()}
 
         # Mock helper methods
-        group_writer._device_group_exists = Mock(side_effect=lambda name: name == "existing_group")
-        group_writer._device_group_config_matches = Mock(return_value=False)  # Config differs
+        group_writer._device_group_exists = Mock(
+            side_effect=lambda name: name == "existing_group"
+        )
+        group_writer._device_group_config_matches = Mock(
+            return_value=False
+        )  # Config differs
         group_writer._update_device_group = Mock()
         group_writer._apply_target_groups = Mock()
 
@@ -3137,10 +3661,14 @@ class TestGroupWriter:
         # Assert: Verify existence and config matching checks
         group_writer._device_group_exists.assert_any_call("existing_group")
         group_writer._device_group_exists.assert_any_call("new_group")
-        group_writer._device_group_config_matches.assert_called_once_with("existing_group", existing_group)
+        group_writer._device_group_config_matches.assert_called_once_with(
+            "existing_group", existing_group
+        )
 
         # Assert: Verify incremental update for existing group
-        group_writer._update_device_group.assert_called_once_with("existing_group", existing_group)
+        group_writer._update_device_group.assert_called_once_with(
+            "existing_group", existing_group
+        )
 
         # Assert: Verify creation of new group
         mock_sysfs.write_sysfs.assert_any_call(
@@ -3149,24 +3677,34 @@ class TestGroupWriter:
 
         # Assert: Verify group-level attributes are set
         expected_attr_calls = [
-            call("/sys/kernel/scst_tgt/device_groups/new_group/other_attr", "value2", check_result=False)
+            call(
+                "/sys/kernel/scst_tgt/device_groups/new_group/other_attr",
+                "value2",
+                check_result=False,
+            )
         ]
         mock_sysfs.write_sysfs.assert_has_calls(expected_attr_calls, any_order=True)
 
         # Assert: Verify device membership management
         expected_device_calls = [
-            call("/sys/kernel/scst_tgt/device_groups/new_group/devices/mgmt", "add disk3")
+            call(
+                "/sys/kernel/scst_tgt/device_groups/new_group/devices/mgmt", "add disk3"
+            )
         ]
         mock_sysfs.write_sysfs.assert_has_calls(expected_device_calls, any_order=True)
 
         # Assert: Verify target group configuration delegation
-        expected_target_group_calls = [
-            call("new_group", new_group.target_groups)
-        ]
+        expected_target_group_calls = [call("new_group", new_group.target_groups)]
         group_writer._apply_target_groups.assert_has_calls(expected_target_group_calls)
 
         # Assert: Verify debug logging
-        mock_logger.debug.assert_any_call("Device group %s config differs, updating incrementally", "existing_group")
+        mock_logger.debug.assert_any_call(
+            "Device group %s config differs, updating incrementally", "existing_group"
+        )
         mock_logger.debug.assert_any_call("Created device group %s", "new_group")
-        mock_logger.debug.assert_any_call("Set device group attribute %s.%s = %s", "new_group", "other_attr", "value2")
-        mock_logger.debug.assert_any_call("Added device %s to device group %s", "disk3", "new_group")
+        mock_logger.debug.assert_any_call(
+            "Set device group attribute %s.%s = %s", "new_group", "other_attr", "value2"
+        )
+        mock_logger.debug.assert_any_call(
+            "Added device %s to device group %s", "disk3", "new_group"
+        )


### PR DESCRIPTION
`TargetWriter.ensure_hardware_targets_enabled` referenced `self.DRIVER_ATTRIBUTES` which didn't exist, causing `AttributeError` before virtual FC targets with `node_name`/`parent_host `could be created.

Centralized `DRIVER_ATTRIBUTES` in _constants.py_ and added missing qla2x00t driver attributes. Updated _admin.py_, _target_reader.py_, and _target_writer.py_ to import from constants instead of local definitions.