### PR TITLE
NAS-141073 / 27.0.0-BETA.1 / Update to handle recently added pr_dump_dir system attr for dev_disk

### DIFF
--- a/scstadmin/admin.py
+++ b/scstadmin/admin.py
@@ -411,7 +411,7 @@ class SCSTAdmin:
                 handler_mgmt = f"{handler_path}/mgmt"
                 for device in self.sysfs.list_directory(handler_path):
                     # Skip handler attributes - only remove actual devices
-                    if device not in self.sysfs.HANDLER_SYSTEM_ATTRS:
+                    if not self.sysfs.is_handler_system_attr(device, handler):
                         try:
                             self.sysfs.write_sysfs(handler_mgmt, f"del_device {device}")
                         except SCSTError:

--- a/scstadmin/sysfs.py
+++ b/scstadmin/sysfs.py
@@ -56,6 +56,7 @@ class SCSTSysfs:
     MGMT_INTERFACE = "mgmt"
     ENABLED_ATTR = "enabled"
     HANDLER_SYSTEM_ATTRS = {"mgmt", "type", "trace_level"}
+    PER_HANDLER_SYSTEM_ATTRS = {"dev_disk": {"pr_dump_dir"}}
 
     def __init__(self, timeout: int = SCSTConstants.DEFAULT_TIMEOUT):
         self.timeout = timeout
@@ -199,6 +200,16 @@ class SCSTSysfs:
             return [f for f in os.listdir(path) if not f.startswith(".")]
         except OSError:
             return []
+
+    def is_handler_system_attr(
+        self, attr_name: str, handler_name: str | None = None
+    ) -> bool:
+        """Check if an item represents a handler system attr."""
+        if attr_name in self.HANDLER_SYSTEM_ATTRS:
+            return True
+        if handler_name:
+            return attr_name in self.PER_HANDLER_SYSTEM_ATTRS.get(handler_name, {})
+        return False
 
     def is_valid_sysfs_directory(
         self, base_path: str, item_name: str, exclude_mgmt: bool = True


### PR DESCRIPTION
Recently `pr_dump_dir` was an attribute added to `dev_disk` handler.  Without this corresponding change a `pyscstadmin -clear_config` would produce the following dmesg output:
```
[12449.018841] scst: ***ERROR***: Syntax error on "del_device"
[12449.021722] scst: ***ERROR***: Syntax error on "del_device"
```
